### PR TITLE
Fix receivable settlement double-counting and improve counter UI

### DIFF
--- a/app/Filament/Admin/Resources/Users/Schemas/UserForm.php
+++ b/app/Filament/Admin/Resources/Users/Schemas/UserForm.php
@@ -22,6 +22,17 @@ class UserForm
                     ->label('Email address')
                     ->email()
                     ->required(),
+                TextInput::make('password')
+                    ->label('Password')
+                    ->password()
+                    ->revealable()
+                    ->maxLength(255)
+                    ->autocomplete('new-password')
+                    ->helperText(fn (string $operation): string => $operation === 'edit'
+                        ? 'Leave blank to keep the current password.'
+                        : '')
+                    ->required(fn (string $operation): bool => $operation === 'create')
+                    ->dehydrated(fn (?string $state): bool => filled($state)),
                 // Textarea::make('two_factor_secret')
                 //     ->columnSpanFull(),
                 // Textarea::make('two_factor_recovery_codes')

--- a/app/Http/Controllers/Prints/ClosingStatementPdfPrintController.php
+++ b/app/Http/Controllers/Prints/ClosingStatementPdfPrintController.php
@@ -64,6 +64,12 @@ class ClosingStatementPdfPrintController extends Controller
             abort(404, "Closing statement {$ctNumber} not found");
         }
 
+        // Only finalised counters may be printed. While a counter is still OPEN its
+        // figures are not final, so printing the statement or any report is blocked.
+        if (! in_array(strtoupper((string) $closing->status), ['CLOSED', 'REPORTED'], true)) {
+            abort(403, "Counter {$ctNumber} must be closed before it can be printed.");
+        }
+
         // If a specific report type is requested, generate that report
         if ($report && in_array($report, $allowedReports)) {
             $data = $this->prepareClosingData($closing);

--- a/app/Http/Controllers/WebController.php
+++ b/app/Http/Controllers/WebController.php
@@ -10,6 +10,7 @@ use App\Models\ExpenseVoucher;
 use App\Models\Panel;
 use App\Models\Patient;
 use App\Models\PatientManager;
+use App\Models\PaymentMethod;
 use App\Models\Receaveable;
 use App\Models\Reception;
 use App\Models\Service;
@@ -563,6 +564,7 @@ class WebController extends Controller
         // dd($pageData['services']);
 
         $pageData['panelCompanies'] = Panel::all();
+        $pageData['paymentMethods'] = PaymentMethod::all();
 
         return Inertia::render('counter/income', $pageData);
     }
@@ -1099,6 +1101,8 @@ class WebController extends Controller
         return Inertia::render('counter/receaveables', [
             'openCounter' => $openCounter,
             'receaveables' => $receaveables,
+            'paymentMethods' => PaymentMethod::all(),
+            'panelCompanies' => Panel::all(),
         ]);
     }
 

--- a/app/Http/Controllers/WebController.php
+++ b/app/Http/Controllers/WebController.php
@@ -367,7 +367,7 @@ class WebController extends Controller
         $year && $query->whereYear('created_at', $year);
         $month && $query->whereMonth('created_at', $month);
 
-        $data = $query->paginate(8);
+        $data = $query->latest('id')->paginate(8);
 
         return Inertia::render('counter/list', [
             'yearSelected' => $year,
@@ -933,18 +933,21 @@ class WebController extends Controller
 
         $transaction = $receaveable->transaction;
 
-        $elements = $transaction->elements;
-
-        if ($elements->count() !== 1) {
+        if ($transaction->elements->count() !== 1) {
             return redirect()->back()->withErrors(['error' => 'Invalid receaveable transaction elements.']);
         }
-
-        $element = $elements->first();
 
         DB::beginTransaction();
 
         try {
 
+            // A receivable settlement is a cash/accounts-receivable movement, not new
+            // service revenue: the full service amount was already recognised on the
+            // original transaction's element. Recording only the payment Transaction
+            // (Dr Cash / Cr A/R, see AbacusClosingService) keeps the shift cash totals
+            // correct while avoiding a duplicate INCOME TransactionElement that would
+            // double-count the income report and the service order's totals when the
+            // receivable is collected within the same shift.
             $newTransaction = Transaction::create([
                 'closing_id' => $openCounter->id,
                 'created_by' => $request->user()->id,
@@ -954,20 +957,6 @@ class WebController extends Controller
                 'amount' => $validatedData['amount_to_collect'],
                 'panel_id' => $validatedData['payment_method'] === 'PANEL' ? $validatedData['panel_id'] : null,
                 'receaveable_id' => $receaveable->id,
-            ]);
-
-            // Receivable payment element — do NOT copy service_id, otherwise
-            // TransactionElementObserver::created spawns a duplicate ServiceOrder.
-            // Reuse the original element's service_order_id so reports stay linked.
-            $newTransactionElement = TransactionElement::create([
-                'closing_id' => $openCounter->id,
-                'transaction_id' => $newTransaction->id,
-                'created_by' => $request->user()->id,
-                'patient_id' => $receaveable->patient_id,
-                'type' => $element->type,
-                'income_or_expense' => $element->income_or_expense,
-                'service_order_id' => $element->service_order_id,
-                'amount' => $validatedData['amount_to_collect'],
                 'notes' => $validatedData['note'] ?? null,
             ]);
 

--- a/resources/js/elements/receaveables/ReceaveAblesButton.tsx
+++ b/resources/js/elements/receaveables/ReceaveAblesButton.tsx
@@ -23,30 +23,45 @@ import {
 } from '@/components/ui/select';
 import { Spinner } from '@/components/ui/spinner';
 import { receaveablesPayment } from '@/routes';
-import { Receaveable } from '@/types';
-import { Form } from '@inertiajs/react';
+import { Panel, PaymentMethod, Receaveable } from '@/types';
+import { Form, usePage } from '@inertiajs/react';
 
 interface ReceaveAblesButtonProps {
     receaveable: Receaveable;
+    paymentMethods?: PaymentMethod[];
+    panelCompanies?: Panel[];
     onConfirm?: (amountCollected: number, note?: string) => void;
 }
 
 export default function ReceaveAblesButton({
     receaveable,
+    paymentMethods,
+    panelCompanies,
     onConfirm,
 }: ReceaveAblesButtonProps) {
+    const sharedProps = usePage<{
+        paymentMethods?: PaymentMethod[];
+        panelCompanies?: Panel[];
+    }>().props;
+
+    const methods = paymentMethods ?? sharedProps.paymentMethods ?? [];
+    const panels = panelCompanies ?? sharedProps.panelCompanies ?? [];
+
     const [amountToCollect] = useState<string>(
         String(receaveable.amount ?? ''),
     );
     const [amountToReceave, setAmountToReceave] = useState<string>(
         String(receaveable.amount ?? ''),
     );
-    const [paymentMethod, setPaymentMethod] = useState<string>('CASH');
+    const [paymentMethod, setPaymentMethod] = useState<string>(
+        methods[0]?.slug ?? 'CASH',
+    );
+    const [panelId, setPanelId] = useState<string>('');
     const [note, setNote] = useState('');
 
-    // Load Error messages from
-
-    console.log('Receaveable in button:', receaveable);
+    const requiresPanel =
+        methods.find((method) => method.slug === paymentMethod)?.payables ===
+        'panel';
 
     return (
         <Dialog>
@@ -151,20 +166,46 @@ export default function ReceaveAblesButton({
                                         <SelectValue placeholder="Select payment method" />
                                     </SelectTrigger>
                                     <SelectContent>
-                                        <SelectItem value="CASH">
-                                            Cash
-                                        </SelectItem>
-                                        <SelectItem value="CARD">
-                                            Card
-                                        </SelectItem>
-                                        <SelectItem value="CHEQUE">
-                                            Cheque
-                                        </SelectItem>
-                                        {/* <SelectItem value="INSURANCE">INSURANCE</SelectItem> */}
+                                        {methods.map((method) => (
+                                            <SelectItem
+                                                key={method.id}
+                                                value={method.slug}
+                                            >
+                                                {method.name}
+                                            </SelectItem>
+                                        ))}
                                     </SelectContent>
                                 </Select>
                                 <InputError message={errors.payment_method} />
                             </div>
+
+                            {requiresPanel && (
+                                <div className="grid gap-2">
+                                    <Label htmlFor="panel_id" required>
+                                        Panel Company
+                                    </Label>
+                                    <Select
+                                        value={panelId}
+                                        onValueChange={setPanelId}
+                                        name="panel_id"
+                                    >
+                                        <SelectTrigger>
+                                            <SelectValue placeholder="Select panel company" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {panels.map((company) => (
+                                                <SelectItem
+                                                    key={company.id}
+                                                    value={String(company.id)}
+                                                >
+                                                    {company.name}
+                                                </SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                    <InputError message={errors.panel_id} />
+                                </div>
+                            )}
 
                             <div className="grid gap-2">
                                 <Label htmlFor="receaveable_note">

--- a/resources/js/pages/counter/list.tsx
+++ b/resources/js/pages/counter/list.tsx
@@ -160,6 +160,9 @@ export default function CountersList() {
                                     Info
                                 </th>
                                 <th scope="col" className="px-6 py-3">
+                                    Status
+                                </th>
+                                <th scope="col" className="px-6 py-3">
                                     Opening Amount
                                 </th>
                                 <th scope="col" className="px-6 py-3">
@@ -167,6 +170,9 @@ export default function CountersList() {
                                 </th>
                                 <th scope="col" className="px-6 py-3">
                                     Expense Payed
+                                </th>
+                                <th scope="col" className="px-6 py-3">
+                                    Opened At
                                 </th>
                                 <th scope="col" className="px-6 py-3">
                                     Closed At
@@ -207,6 +213,11 @@ export default function CountersList() {
                                             </Link>
                                         </td>
                                         <td className="px-6 py-3">
+                                            <CounterStatusBadge
+                                                status={p.status}
+                                            />
+                                        </td>
+                                        <td className="px-6 py-3">
                                             {p.opening_amount}
                                         </td>
                                         <td className="px-6 py-3">
@@ -216,7 +227,10 @@ export default function CountersList() {
                                             {p.expense_payed}
                                         </td>
                                         <td className="px-6 py-3">
-                                            {p.closed_at}
+                                            {formatDateTime(p.created_at)}
+                                        </td>
+                                        <td className="px-6 py-3">
+                                            {formatDateTime(p.closed_at)}
                                         </td>
                                     </tr>
                                 );
@@ -224,7 +238,7 @@ export default function CountersList() {
                         </tbody>
                         <tfoot>
                             <tr>
-                                <td colSpan={4}>
+                                <td colSpan={7}>
                                     <TablePagination
                                         currentPage={closings.current_page}
                                         lastPage={closings.last_page}
@@ -239,6 +253,43 @@ export default function CountersList() {
                 </div>
             </div>
         </AppLayout>
+    );
+}
+
+function formatDateTime(value?: string | null) {
+    if (!value) {
+        return '—';
+    }
+
+    const parsed = new Date(value);
+
+    if (Number.isNaN(parsed.getTime())) {
+        return value;
+    }
+
+    return parsed.toLocaleString();
+}
+
+function CounterStatusBadge({ status }: { status?: string }) {
+    const normalized = (status ?? '').toUpperCase();
+
+    const styles: Record<string, string> = {
+        OPEN: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
+        CLOSED: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+        REPORTED:
+            'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
+    };
+
+    const badgeClass =
+        styles[normalized] ??
+        'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200';
+
+    return (
+        <span
+            className={`inline-flex rounded-full px-2 py-0.5 text-xs font-semibold ${badgeClass}`}
+        >
+            {normalized || 'UNKNOWN'}
+        </span>
     );
 }
 

--- a/resources/js/pages/counter/receaveables.tsx
+++ b/resources/js/pages/counter/receaveables.tsx
@@ -1,7 +1,7 @@
 import ReceaveAblesButton from '@/elements/receaveables/ReceaveAblesButton';
 import AppLayout from '@/layouts/app-layout';
 import { counter, home, patientsRegisterPsNumber } from '@/routes';
-import { type BreadcrumbItem } from '@/types';
+import { type BreadcrumbItem, type Panel, type PaymentMethod } from '@/types';
 import { Head, Link, usePage } from '@inertiajs/react';
 
 interface PageProps {
@@ -19,6 +19,8 @@ interface PageProps {
         per_page: number;
         [key: string]: any;
     };
+    paymentMethods: PaymentMethod[];
+    panelCompanies: Panel[];
     [key: string]: any;
 }
 
@@ -38,7 +40,8 @@ export default function ReveaveablesList() {
         },
     ];
 
-    const { receaveables } = usePage<PageProps>().props;
+    const { receaveables, paymentMethods, panelCompanies } =
+        usePage<PageProps>().props;
 
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
@@ -114,6 +117,8 @@ export default function ReveaveablesList() {
                                         <td className="px-6 py-3">
                                             <ReceaveAblesButton
                                                 receaveable={r}
+                                                paymentMethods={paymentMethods}
+                                                panelCompanies={panelCompanies}
                                             />
                                         </td>
                                     </tr>

--- a/resources/js/pages/counter/view.tsx
+++ b/resources/js/pages/counter/view.tsx
@@ -174,6 +174,17 @@ const tabConfig: { key: CounterTab; label: string; color: string }[] = [
 const CounterViewTabs = ({ openCounter }: { openCounter: any }) => {
     const [activeTab, setActiveTab] = useState<CounterTab>('general');
 
+    // A counter statement can only be printed once the shift is closed (or
+    // reported). While it is still OPEN the figures are not final, so the print
+    // and report tabs are hidden to prevent printing an in-progress counter.
+    const counterStatus = String(openCounter.status ?? '').toUpperCase();
+    const canPrint =
+        counterStatus === 'CLOSED' || counterStatus === 'REPORTED';
+
+    const visibleTabs = canPrint
+        ? tabConfig
+        : tabConfig.filter((tab) => tab.key === 'general');
+
     const closingUrl = printClosingStatement({
         year: openCounter.year,
         month: openCounter.month,
@@ -183,7 +194,7 @@ const CounterViewTabs = ({ openCounter }: { openCounter: any }) => {
     return (
         <>
             <div className="flex flex-row gap-2 divide-y-0 divide-gray-300 overflow-x-auto border-b">
-                {tabConfig.map((tab) => (
+                {visibleTabs.map((tab) => (
                     <button
                         key={tab.key}
                         onClick={() => setActiveTab(tab.key)}

--- a/resources/js/pages/counter/view.tsx
+++ b/resources/js/pages/counter/view.tsx
@@ -178,8 +178,7 @@ const CounterViewTabs = ({ openCounter }: { openCounter: any }) => {
     // reported). While it is still OPEN the figures are not final, so the print
     // and report tabs are hidden to prevent printing an in-progress counter.
     const counterStatus = String(openCounter.status ?? '').toUpperCase();
-    const canPrint =
-        counterStatus === 'CLOSED' || counterStatus === 'REPORTED';
+    const canPrint = counterStatus === 'CLOSED' || counterStatus === 'REPORTED';
 
     const visibleTabs = canPrint
         ? tabConfig

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -188,3 +188,18 @@ export interface ExpenseVoucher {
 }
 
 export type Receivable = Receaveable;
+
+export interface PaymentMethod {
+    id: number;
+    name: string;
+    slug: string;
+    id_required: boolean;
+    payables?: string | null;
+    [key: string]: unknown;
+}
+
+export interface Panel {
+    id: number;
+    name: string;
+    [key: string]: unknown;
+}

--- a/tests/Feature/Filament/Admin/UserResourceTest.php
+++ b/tests/Feature/Filament/Admin/UserResourceTest.php
@@ -6,6 +6,7 @@ use App\Filament\Admin\Resources\Users\Pages\ListUsers;
 use App\Filament\Admin\Resources\Users\Pages\ViewUser;
 use App\Models\Administrator;
 use App\Models\User;
+use Illuminate\Support\Facades\Hash;
 
 beforeEach(function () {
     $this->user = User::factory()->create();
@@ -29,4 +30,45 @@ test('user view page renders', function () {
 test('user edit page renders', function () {
     $user = User::factory()->create();
     Livewire\Livewire::test(EditUser::class, ['record' => $user->getRouteKey()])->assertSuccessful();
+});
+
+test('a password can be set when creating a user', function () {
+    Livewire\Livewire::test(CreateUser::class)
+        ->fillForm([
+            'name' => 'Password User',
+            'email' => 'password-user@example.com',
+            'password' => 'super-secret',
+            'login_attempts' => 0,
+            'is_active' => true,
+            'patientManagerProfiles' => [],
+        ])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    $created = User::where('email', 'password-user@example.com')->first();
+    expect($created)->not->toBeNull();
+    expect(Hash::check('super-secret', $created->password))->toBeTrue();
+});
+
+test('editing a user without a password keeps the existing one', function () {
+    $user = User::factory()->create();
+    $originalHash = $user->fresh()->password;
+
+    Livewire\Livewire::test(EditUser::class, ['record' => $user->getRouteKey()])
+        ->fillForm(['password' => ''])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    expect($user->fresh()->password)->toBe($originalHash);
+});
+
+test('editing a user with a new password updates it', function () {
+    $user = User::factory()->create();
+
+    Livewire\Livewire::test(EditUser::class, ['record' => $user->getRouteKey()])
+        ->fillForm(['password' => 'a-new-password'])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    expect(Hash::check('a-new-password', $user->fresh()->password))->toBeTrue();
 });

--- a/tests/Feature/Web/ClosingStatementPrintRestrictionTest.php
+++ b/tests/Feature/Web/ClosingStatementPrintRestrictionTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use App\Models\Closing;
+use App\Models\User;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+
+function printUrlFor(Closing $closing): string
+{
+    return route('print-closing-statement', [
+        'year' => $closing->year,
+        'month' => $closing->month,
+        'number' => $closing->number,
+    ]);
+}
+
+test('an open counter cannot be printed', function () {
+    $user = User::factory()->create();
+    $closing = Closing::factory()->create(['status' => 'OPEN']);
+
+    actingAs($user);
+
+    get(printUrlFor($closing))->assertForbidden();
+});
+
+test('a closed counter can be printed', function () {
+    $user = User::factory()->create();
+    $closing = Closing::factory()->closed()->create();
+
+    actingAs($user);
+
+    get(printUrlFor($closing))->assertOk();
+});

--- a/tests/Feature/Web/MyCounterListTest.php
+++ b/tests/Feature/Web/MyCounterListTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use App\Models\Closing;
+use App\Models\User;
+use Inertia\Testing\AssertableInertia as Assert;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+
+test('my counter list shows the latest counter at the top', function () {
+    $user = User::factory()->create();
+
+    $first = Closing::factory()->create(['receptionist_id' => $user->id]);
+    $second = Closing::factory()->create(['receptionist_id' => $user->id]);
+    $latest = Closing::factory()->create(['receptionist_id' => $user->id]);
+
+    actingAs($user);
+
+    get(route('my-counter-list'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('counter/list')
+            ->where('closings.data.0.id', $latest->id)
+            ->where('closings.data.2.id', $first->id)
+        );
+});

--- a/tests/Feature/Web/ReceaveablesPaymentTest.php
+++ b/tests/Feature/Web/ReceaveablesPaymentTest.php
@@ -1,0 +1,79 @@
+<?php
+
+use App\Models\Closing;
+use App\Models\Patient;
+use App\Models\Receaveable;
+use App\Models\ServiceOrder;
+use App\Models\Transaction;
+use App\Models\TransactionElement;
+use App\Models\User;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\post;
+
+test('collecting a receivable in the same shift does not double count income or the service order', function () {
+    $user = User::factory()->create();
+    $closing = Closing::factory()->create([
+        'status' => 'open',
+        'receptionist_id' => $user->id,
+    ]);
+    $patient = Patient::factory()->create();
+    $serviceOrder = ServiceOrder::factory()->create(['patient_id' => $patient->id]);
+
+    // Original sale: full service amount (1000) recognised on the element, but the
+    // patient only paid 600 at the counter, leaving a 400 receivable.
+    $originalTransaction = Transaction::factory()->create([
+        'closing_id' => $closing->id,
+        'patient_id' => $patient->id,
+        'income_or_expense' => 'INCOME',
+        'amount' => 600,
+    ]);
+
+    TransactionElement::factory()->create([
+        'closing_id' => $closing->id,
+        'transaction_id' => $originalTransaction->id,
+        'patient_id' => $patient->id,
+        'service_order_id' => $serviceOrder->id,
+        'service_id' => null,
+        'income_or_expense' => 'INCOME',
+        'amount' => 1000,
+    ]);
+
+    $receaveable = Receaveable::factory()->create([
+        'patient_id' => $patient->id,
+        'transaction_id' => $originalTransaction->id,
+        'amount' => 400,
+        'orignal_amount' => 400,
+        'status' => 'unpaid',
+    ]);
+
+    actingAs($user);
+
+    post(route('receaveables-payment'), [
+        'receaveable_id' => $receaveable->id,
+        'payment_method' => 'CASH',
+        'amount_to_collect' => 400,
+    ])->assertRedirect();
+
+    // The settlement is recorded as a cash Transaction (Dr Cash / Cr A/R) ...
+    $settlement = Transaction::where('receaveable_id', $receaveable->id)->first();
+    expect($settlement)->not->toBeNull();
+    expect((float) $settlement->amount)->toBe(400.0);
+    expect($settlement->income_or_expense)->toBe('INCOME');
+
+    // ... but it must NOT create a second income element.
+    expect($settlement->elements()->count())->toBe(0);
+
+    // The service order's recognised income stays at the original service amount,
+    // and only the original element remains linked to it.
+    $serviceOrderIncome = TransactionElement::where('service_order_id', $serviceOrder->id)
+        ->where('income_or_expense', 'INCOME')
+        ->sum('amount');
+    expect((float) $serviceOrderIncome)->toBe(1000.0);
+    expect(TransactionElement::where('service_order_id', $serviceOrder->id)->count())->toBe(1);
+
+    // The receivable is fully settled.
+    $receaveable->refresh();
+    expect($receaveable->status)->toBe('paid');
+    expect((float) $receaveable->amount)->toBe(0.0);
+});

--- a/tests/Feature/Web/WebRoutesTest.php
+++ b/tests/Feature/Web/WebRoutesTest.php
@@ -1,7 +1,9 @@
 <?php
 
 use App\Models\Closing;
+use App\Models\PaymentMethod;
 use App\Models\User;
+use Inertia\Testing\AssertableInertia as Assert;
 
 // --- Guests are redirected ---
 
@@ -54,6 +56,24 @@ test('authenticated user can access receivables page', function () {
     $this->actingAs($user)
         ->get(route('receaveables'))
         ->assertOk();
+});
+
+test('receivables page passes payment methods from the database', function () {
+    $user = User::factory()->create();
+    Closing::factory()->create(['receptionist_id' => $user->id, 'status' => 'open']);
+
+    PaymentMethod::create(['slug' => 'CASH', 'name' => 'Cash', 'id_required' => false]);
+    PaymentMethod::create(['slug' => 'PANEL', 'name' => 'Panel', 'id_required' => false, 'payables' => 'panel']);
+
+    $this->actingAs($user)
+        ->get(route('receaveables'))
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('counter/receaveables')
+            ->has('paymentMethods', 2)
+            ->where('paymentMethods.0.slug', 'CASH')
+            ->where('paymentMethods.1.slug', 'PANEL')
+            ->has('panelCompanies')
+        );
 });
 
 test('authenticated user can access counter list page', function () {


### PR DESCRIPTION
## Summary

This PR fixes a critical accounting issue where collecting a receivable within the same shift would double-count income in reports and service order totals. It also improves the counter management UI with better status visibility and date formatting, adds payment method configuration support, and enhances user management with password handling.

## Key Changes

### Receivable Settlement Fix
- **Removed duplicate TransactionElement creation** when settling receivables: The settlement transaction now records only the cash/A/R movement (Dr Cash / Cr A/R) without creating a new INCOME element, preventing double-counting of service revenue
- Added detailed comments explaining why the element is not created—the full service amount was already recognized on the original transaction
- Updated `receaveablesPayment()` to create only the settlement Transaction, not the associated element

### Counter Management UI Improvements
- **Counter list page** now displays:
  - New "Status" column with color-coded badges (OPEN/CLOSED/REPORTED)
  - New "Opened At" column showing when the counter was created
  - Improved date formatting with `formatDateTime()` helper for both timestamps
  - Latest counters appear first (sorted by `id DESC`)
- **Counter view page** now restricts printing:
  - Print and report tabs are hidden while counter is OPEN
  - Only CLOSED or REPORTED counters can be printed
  - Added authorization check in `ClosingStatementPdfPrintController` to prevent printing open counters

### Payment Method Configuration
- **Dynamic payment methods**: Replaced hardcoded CASH/CARD/CHEQUE options with database-driven `PaymentMethod` records
- **Panel company support**: Added conditional "Panel Company" field that appears only when the selected payment method requires it (via `payables` attribute)
- Updated `ReceaveAblesButton` component to accept and display payment methods and panel companies from props or shared page data
- Pass payment methods and panel companies to receivables page via controller

### User Management Enhancements
- Added password field to user creation/editing forms in Filament
- Password is required when creating a user, optional when editing (with helper text "Leave blank to keep the current password")
- Proper password hashing via `dehydrated()` callback
- Added comprehensive tests for password creation and updates

### Test Coverage
- New test: `ReceaveablesPaymentTest` validates that collecting a receivable doesn't create duplicate income elements
- New test: `ClosingStatementPrintRestrictionTest` ensures only closed/reported counters can be printed
- New test: `MyCounterListTest` verifies latest counters appear first
- New test: `WebRoutesTest` validates payment methods are passed to receivables page
- New tests: `UserResourceTest` covers password creation and updates

## Implementation Details

- The receivable settlement fix maintains the original service order link (via `service_order_id` on the original element) while avoiding duplicate INCOME recognition
- Counter status badges use Tailwind color classes with dark mode support
- Payment method configuration uses a `payables` attribute to determine if a panel company selector should be shown
- User password handling uses Filament's `dehydrated()` callback to conditionally hash only when a new password is provided

https://claude.ai/code/session_017WTqn2ZEg8vzp5bgvV2NfH