### PR TITLE
Allow administrators to print open counter statements

### DIFF
--- a/app/Http/Controllers/Prints/ClosingStatementPdfPrintController.php
+++ b/app/Http/Controllers/Prints/ClosingStatementPdfPrintController.php
@@ -65,8 +65,11 @@ class ClosingStatementPdfPrintController extends Controller
         }
 
         // Only finalised counters may be printed. While a counter is still OPEN its
-        // figures are not final, so printing the statement or any report is blocked.
-        if (! in_array(strtoupper((string) $closing->status), ['CLOSED', 'REPORTED'], true)) {
+        // figures are not final, so printing the statement or any report is blocked
+        // for regular staff. Administrators may still print an in-progress counter.
+        $isFinalised = in_array(strtoupper((string) $closing->status), ['CLOSED', 'REPORTED'], true);
+
+        if (! $isFinalised && ! $request->user()?->isAdmin()) {
             abort(403, "Counter {$ctNumber} must be closed before it can be printed.");
         }
 

--- a/resources/js/pages/counter/view.tsx
+++ b/resources/js/pages/counter/view.tsx
@@ -176,9 +176,13 @@ const CounterViewTabs = ({ openCounter }: { openCounter: any }) => {
 
     // A counter statement can only be printed once the shift is closed (or
     // reported). While it is still OPEN the figures are not final, so the print
-    // and report tabs are hidden to prevent printing an in-progress counter.
+    // and report tabs are hidden for regular staff. Administrators may still
+    // print an in-progress counter.
+    const { auth } = usePage().props as unknown as { auth: any };
+    const isAdmin = (auth?.user?.profiles?.admin?.length ?? 0) > 0;
     const counterStatus = String(openCounter.status ?? '').toUpperCase();
-    const canPrint = counterStatus === 'CLOSED' || counterStatus === 'REPORTED';
+    const canPrint =
+        counterStatus === 'CLOSED' || counterStatus === 'REPORTED' || isAdmin;
 
     const visibleTabs = canPrint
         ? tabConfig

--- a/tests/Feature/Web/ClosingStatementPrintRestrictionTest.php
+++ b/tests/Feature/Web/ClosingStatementPrintRestrictionTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\Administrator;
 use App\Models\Closing;
 use App\Models\User;
 
@@ -15,13 +16,23 @@ function printUrlFor(Closing $closing): string
     ]);
 }
 
-test('an open counter cannot be printed', function () {
+test('an open counter cannot be printed by regular staff', function () {
     $user = User::factory()->create();
     $closing = Closing::factory()->create(['status' => 'OPEN']);
 
     actingAs($user);
 
     get(printUrlFor($closing))->assertForbidden();
+});
+
+test('an admin can print an open counter', function () {
+    $user = User::factory()->create();
+    Administrator::create(['user_id' => $user->id, 'authority' => 'administrator']);
+    $closing = Closing::factory()->create(['status' => 'OPEN']);
+
+    actingAs($user);
+
+    get(printUrlFor($closing))->assertOk();
 });
 
 test('a closed counter can be printed', function () {


### PR DESCRIPTION
## Summary
This change allows administrators to print counter statements that are still in OPEN status, while maintaining the restriction for regular staff. Previously, only CLOSED or REPORTED counters could be printed by any user.

## Key Changes

- **Backend Authorization:** Updated `ClosingStatementPdfPrintController` to check if the user is an administrator before blocking OPEN counter printing
- **Frontend UI:** Modified `counter/view.tsx` to show the print tab for administrators even when the counter is OPEN
- **Test Coverage:** Added test case verifying administrators can print OPEN counters, and clarified existing test name to specify it applies to regular staff

## Implementation Details

- The authorization check uses `$request->user()?->isAdmin()` to determine admin status
- Frontend checks `auth?.user?.profiles?.admin?.length` to conditionally display print functionality
- Comments updated to clarify that the restriction applies to "regular staff" while administrators have broader permissions
- Maintains data integrity by still preventing regular staff from printing in-progress counters with non-final figures

https://claude.ai/code/session_017WTqn2ZEg8vzp5bgvV2NfH