### PR TITLE
Fix timezone handling in date range filters across reports

### DIFF
--- a/app/Exports/ExpenseReportExport.php
+++ b/app/Exports/ExpenseReportExport.php
@@ -2,6 +2,7 @@
 
 namespace App\Exports;
 
+use App\Helpers\DateHelper;
 use App\Models\Closing;
 use App\Models\TransactionElement;
 use Illuminate\Contracts\Support\Responsable;
@@ -27,10 +28,10 @@ class ExpenseReportExport implements FromQuery, Responsable, ShouldAutoSize, Wit
             ->where('income_or_expense', 'EXPENSE');
 
         if ($this->filters['from'] ?? null) {
-            $query->whereDate('transaction_elements.created_at', '>=', $this->filters['from']);
+            $query->where('transaction_elements.created_at', '>=', DateHelper::dayStartUtc($this->filters['from']));
         }
         if ($this->filters['until'] ?? null) {
-            $query->whereDate('transaction_elements.created_at', '<=', $this->filters['until']);
+            $query->where('transaction_elements.created_at', '<=', DateHelper::dayEndUtc($this->filters['until']));
         }
         if ($this->filters['reception_id'] ?? null) {
             $query->whereIn('closing_id', Closing::where('reception_id', $this->filters['reception_id'])->select('id'));
@@ -53,7 +54,7 @@ class ExpenseReportExport implements FromQuery, Responsable, ShouldAutoSize, Wit
     public function map($row): array
     {
         return [
-            $row->created_at?->format('d M Y H:i'),
+            DateHelper::pdfFormat($row->created_at, 'd M Y H:i'),
             $row->transaction?->closing?->ct_number,
             $row->transaction?->tr_number,
             $row->type,

--- a/app/Exports/IncomeReportExport.php
+++ b/app/Exports/IncomeReportExport.php
@@ -2,6 +2,7 @@
 
 namespace App\Exports;
 
+use App\Helpers\DateHelper;
 use App\Models\Closing;
 use App\Models\TransactionElement;
 use Illuminate\Contracts\Support\Responsable;
@@ -27,10 +28,10 @@ class IncomeReportExport implements FromQuery, Responsable, ShouldAutoSize, With
             ->where('income_or_expense', 'INCOME');
 
         if ($this->filters['from'] ?? null) {
-            $query->whereDate('transaction_elements.created_at', '>=', $this->filters['from']);
+            $query->where('transaction_elements.created_at', '>=', DateHelper::dayStartUtc($this->filters['from']));
         }
         if ($this->filters['until'] ?? null) {
-            $query->whereDate('transaction_elements.created_at', '<=', $this->filters['until']);
+            $query->where('transaction_elements.created_at', '<=', DateHelper::dayEndUtc($this->filters['until']));
         }
         if ($this->filters['reception_id'] ?? null) {
             $query->whereIn('closing_id', Closing::where('reception_id', $this->filters['reception_id'])->select('id'));
@@ -56,7 +57,7 @@ class IncomeReportExport implements FromQuery, Responsable, ShouldAutoSize, With
     public function map($row): array
     {
         return [
-            $row->created_at?->format('d M Y H:i'),
+            DateHelper::pdfFormat($row->created_at, 'd M Y H:i'),
             $row->transaction?->closing?->ct_number,
             $row->transaction?->tr_number,
             $row->type,

--- a/app/Exports/ReceivablesReportExport.php
+++ b/app/Exports/ReceivablesReportExport.php
@@ -2,6 +2,7 @@
 
 namespace App\Exports;
 
+use App\Helpers\DateHelper;
 use App\Models\Receaveable;
 use Illuminate\Contracts\Support\Responsable;
 use Maatwebsite\Excel\Concerns\Exportable;
@@ -24,10 +25,10 @@ class ReceivablesReportExport implements FromQuery, Responsable, ShouldAutoSize,
         $query = Receaveable::query()->with(['transaction', 'patient', 'panel']);
 
         if ($this->filters['from'] ?? null) {
-            $query->whereDate('receaveables.created_at', '>=', $this->filters['from']);
+            $query->where('receaveables.created_at', '>=', DateHelper::dayStartUtc($this->filters['from']));
         }
         if ($this->filters['until'] ?? null) {
-            $query->whereDate('receaveables.created_at', '<=', $this->filters['until']);
+            $query->where('receaveables.created_at', '<=', DateHelper::dayEndUtc($this->filters['until']));
         }
         if ($this->filters['status'] ?? null) {
             $query->where('status', $this->filters['status']);
@@ -47,13 +48,13 @@ class ReceivablesReportExport implements FromQuery, Responsable, ShouldAutoSize,
     public function map($row): array
     {
         return [
-            $row->created_at?->format('d M Y'),
+            DateHelper::pdfFormat($row->created_at, 'd M Y'),
             $row->transaction?->tr_number,
             $row->patient?->name,
             $row->panel?->name,
             number_format((float) $row->orignal_amount, 2),
             number_format((float) $row->amount, 2),
-            $row->due_date?->format('d M Y'),
+            DateHelper::pdfFormat($row->due_date, 'd M Y'),
             $row->status,
         ];
     }

--- a/app/Exports/ServicePerformanceReportExport.php
+++ b/app/Exports/ServicePerformanceReportExport.php
@@ -2,6 +2,7 @@
 
 namespace App\Exports;
 
+use App\Helpers\DateHelper;
 use App\Models\ServiceOrder;
 use Illuminate\Contracts\Support\Responsable;
 use Maatwebsite\Excel\Concerns\Exportable;
@@ -25,8 +26,8 @@ class ServicePerformanceReportExport implements FromQuery, Responsable, ShouldAu
             ->withSum(['transactionElements as income_total' => fn ($q) => $q->where('income_or_expense', 'INCOME')], 'amount')
             ->withSum(['expenseVouchers as voucher_total'], 'amount')
             ->with(['patient', 'service', 'doctor'])
-            ->when($this->filters['from'] ?? null, fn ($q, $date) => $q->whereDate('service_orders.created_at', '>=', $date))
-            ->when($this->filters['until'] ?? null, fn ($q, $date) => $q->whereDate('service_orders.created_at', '<=', $date))
+            ->when($this->filters['from'] ?? null, fn ($q, $date) => $q->where('service_orders.created_at', '>=', DateHelper::dayStartUtc($date)))
+            ->when($this->filters['until'] ?? null, fn ($q, $date) => $q->where('service_orders.created_at', '<=', DateHelper::dayEndUtc($date)))
             ->when($this->filters['type'] ?? null, fn ($q, $type) => $q->where('type', $type))
             ->when($this->filters['status'] ?? null, fn ($q, $status) => $q->where('status', $status))
             ->when($this->filters['service_id'] ?? null, fn ($q, $id) => $q->where('service_id', $id))
@@ -42,7 +43,7 @@ class ServicePerformanceReportExport implements FromQuery, Responsable, ShouldAu
     public function map($row): array
     {
         return [
-            $row->created_at?->format('d M Y'),
+            DateHelper::pdfFormat($row->created_at, 'd M Y'),
             $row->so_number,
             $row->patient?->name,
             $row->service?->name,

--- a/app/Exports/ServiceProviderReportExport.php
+++ b/app/Exports/ServiceProviderReportExport.php
@@ -2,6 +2,7 @@
 
 namespace App\Exports;
 
+use App\Helpers\DateHelper;
 use App\Models\ServiceOrder;
 use Illuminate\Contracts\Support\Responsable;
 use Maatwebsite\Excel\Concerns\Exportable;
@@ -25,8 +26,8 @@ class ServiceProviderReportExport implements FromQuery, Responsable, ShouldAutoS
             ->withSum(['transactionElements as income_total' => fn ($q) => $q->where('income_or_expense', 'INCOME')], 'amount')
             ->withSum(['expenseVouchers as voucher_total'], 'amount')
             ->with(['patient', 'service'])
-            ->when($this->filters['from'] ?? null, fn ($q, $date) => $q->whereDate('service_orders.created_at', '>=', $date))
-            ->when($this->filters['until'] ?? null, fn ($q, $date) => $q->whereDate('service_orders.created_at', '<=', $date))
+            ->when($this->filters['from'] ?? null, fn ($q, $date) => $q->where('service_orders.created_at', '>=', DateHelper::dayStartUtc($date)))
+            ->when($this->filters['until'] ?? null, fn ($q, $date) => $q->where('service_orders.created_at', '<=', DateHelper::dayEndUtc($date)))
             ->when($this->filters['doctor_id'] ?? null, fn ($q, $id) => $q->where('doctor_id', $id))
             ->when($this->filters['service_id'] ?? null, fn ($q, $id) => $q->where('service_id', $id))
             ->when($this->filters['status'] ?? null, fn ($q, $status) => $q->where('status', $status))
@@ -41,7 +42,7 @@ class ServiceProviderReportExport implements FromQuery, Responsable, ShouldAutoS
     public function map($row): array
     {
         return [
-            $row->created_at?->format('d M Y'),
+            DateHelper::pdfFormat($row->created_at, 'd M Y'),
             $row->so_number,
             $row->patient?->name,
             $row->service?->name,

--- a/app/Exports/ServicesReportExport.php
+++ b/app/Exports/ServicesReportExport.php
@@ -2,6 +2,7 @@
 
 namespace App\Exports;
 
+use App\Helpers\DateHelper;
 use App\Models\Closing;
 use App\Models\TransactionElement;
 use Illuminate\Contracts\Support\Responsable;
@@ -33,10 +34,10 @@ class ServicesReportExport implements FromQuery, Responsable, ShouldAutoSize, Wi
             });
 
         if ($this->filters['from'] ?? null) {
-            $query->whereDate('transaction_elements.created_at', '>=', $this->filters['from']);
+            $query->where('transaction_elements.created_at', '>=', DateHelper::dayStartUtc($this->filters['from']));
         }
         if ($this->filters['until'] ?? null) {
-            $query->whereDate('transaction_elements.created_at', '<=', $this->filters['until']);
+            $query->where('transaction_elements.created_at', '<=', DateHelper::dayEndUtc($this->filters['until']));
         }
         if ($this->filters['reception_id'] ?? null) {
             $query->whereIn('closing_id', Closing::where('reception_id', $this->filters['reception_id'])->select('id'));
@@ -62,7 +63,7 @@ class ServicesReportExport implements FromQuery, Responsable, ShouldAutoSize, Wi
     public function map($row): array
     {
         return [
-            $row->created_at?->format('d M Y H:i'),
+            DateHelper::pdfFormat($row->created_at, 'd M Y H:i'),
             $row->transaction?->tr_number,
             $row->service?->name,
             $row->service?->department?->name,

--- a/app/Filament/Admin/Concerns/HasDashboardDateFilters.php
+++ b/app/Filament/Admin/Concerns/HasDashboardDateFilters.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Admin\Concerns;
 
+use App\Helpers\DateHelper;
 use Carbon\Carbon;
 use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\Select;
@@ -54,19 +55,19 @@ trait HasDashboardDateFilters
                     DatePicker::make('startDate')
                         ->label('Start Date')
                         ->visible(fn ($get) => $get('dateRange') === 'custom')
-                        ->default(Carbon::now()->startOfMonth()),
+                        ->default(Carbon::now(DateHelper::timezone())->startOfMonth()),
 
                     DatePicker::make('endDate')
                         ->label('End Date')
                         ->visible(fn ($get) => $get('dateRange') === 'custom')
-                        ->default(Carbon::now()),
+                        ->default(Carbon::now(DateHelper::timezone())),
                 ]),
         ];
     }
 
     protected function calculateDateRange(string $range): array
     {
-        $now = Carbon::now();
+        $now = Carbon::now(DateHelper::timezone());
 
         return match ($range) {
             'today' => [
@@ -114,7 +115,7 @@ trait HasDashboardDateFilters
 
     protected function getLastFinancialYearStart(): Carbon
     {
-        $now = Carbon::now();
+        $now = Carbon::now(DateHelper::timezone());
         $currentFinancialYearStart = $now->copy()->month(7)->startOfMonth();
 
         if ($now->month < 7) {
@@ -135,7 +136,7 @@ trait HasDashboardDateFilters
 
         if (isset($filters['dateRange']) && $filters['dateRange'] === 'custom') {
             if (isset($filters['startDate'])) {
-                return Carbon::parse($filters['startDate']);
+                return Carbon::parse($filters['startDate'], DateHelper::timezone());
             }
         }
 
@@ -143,7 +144,7 @@ trait HasDashboardDateFilters
             return $this->calculateDateRange($filters['dateRange'])['start'];
         }
 
-        return Carbon::now()->startOfMonth();
+        return Carbon::now(DateHelper::timezone())->startOfMonth();
     }
 
     public function getEndDate(): Carbon
@@ -152,7 +153,7 @@ trait HasDashboardDateFilters
 
         if (isset($filters['dateRange']) && $filters['dateRange'] === 'custom') {
             if (isset($filters['endDate'])) {
-                return Carbon::parse($filters['endDate']);
+                return Carbon::parse($filters['endDate'], DateHelper::timezone());
             }
         }
 
@@ -160,6 +161,6 @@ trait HasDashboardDateFilters
             return $this->calculateDateRange($filters['dateRange'])['end'];
         }
 
-        return Carbon::now();
+        return Carbon::now(DateHelper::timezone());
     }
 }

--- a/app/Filament/Admin/Pages/Reports/ExpenseReport.php
+++ b/app/Filament/Admin/Pages/Reports/ExpenseReport.php
@@ -4,6 +4,7 @@ namespace App\Filament\Admin\Pages\Reports;
 
 use App\Enum\TransactionElementType;
 use App\Exports\ExpenseReportExport;
+use App\Helpers\DateHelper;
 use App\Models\Closing;
 use App\Models\ExpenseCategory;
 use App\Models\Reception;
@@ -43,8 +44,8 @@ class ExpenseReport extends Page implements Tables\Contracts\HasTable
     public function mount(): void
     {
         $this->filters = [
-            'from' => now()->startOfMonth()->format('Y-m-d'),
-            'until' => now()->format('Y-m-d'),
+            'from' => now(DateHelper::timezone())->startOfMonth()->format('Y-m-d'),
+            'until' => now(DateHelper::timezone())->format('Y-m-d'),
             'reception_id' => null,
             'type' => null,
             'expense_category_id' => null,
@@ -100,10 +101,10 @@ class ExpenseReport extends Page implements Tables\Contracts\HasTable
                     ]);
 
                 if ($this->filters['from'] ?? null) {
-                    $query->whereDate('transaction_elements.created_at', '>=', $this->filters['from']);
+                    $query->where('transaction_elements.created_at', '>=', DateHelper::dayStartUtc($this->filters['from']));
                 }
                 if ($this->filters['until'] ?? null) {
-                    $query->whereDate('transaction_elements.created_at', '<=', $this->filters['until']);
+                    $query->where('transaction_elements.created_at', '<=', DateHelper::dayEndUtc($this->filters['until']));
                 }
                 if ($this->filters['reception_id'] ?? null) {
                     $query->whereIn('closing_id', Closing::where('reception_id', $this->filters['reception_id'])->select('id'));

--- a/app/Filament/Admin/Pages/Reports/IncomeReport.php
+++ b/app/Filament/Admin/Pages/Reports/IncomeReport.php
@@ -4,6 +4,7 @@ namespace App\Filament\Admin\Pages\Reports;
 
 use App\Enum\TransactionElementType;
 use App\Exports\IncomeReportExport;
+use App\Helpers\DateHelper;
 use App\Models\Closing;
 use App\Models\Reception;
 use App\Models\Service;
@@ -44,8 +45,8 @@ class IncomeReport extends Page implements Tables\Contracts\HasTable
     public function mount(): void
     {
         $this->filters = [
-            'from' => now()->startOfMonth()->format('Y-m-d'),
-            'until' => now()->format('Y-m-d'),
+            'from' => now(DateHelper::timezone())->startOfMonth()->format('Y-m-d'),
+            'until' => now(DateHelper::timezone())->format('Y-m-d'),
             'reception_id' => null,
             'type' => null,
             'service_id' => null,
@@ -107,10 +108,10 @@ class IncomeReport extends Page implements Tables\Contracts\HasTable
                     ]);
 
                 if ($this->filters['from'] ?? null) {
-                    $query->whereDate('transaction_elements.created_at', '>=', $this->filters['from']);
+                    $query->where('transaction_elements.created_at', '>=', DateHelper::dayStartUtc($this->filters['from']));
                 }
                 if ($this->filters['until'] ?? null) {
-                    $query->whereDate('transaction_elements.created_at', '<=', $this->filters['until']);
+                    $query->where('transaction_elements.created_at', '<=', DateHelper::dayEndUtc($this->filters['until']));
                 }
                 if ($this->filters['reception_id'] ?? null) {
                     $query->whereIn('closing_id', Closing::where('reception_id', $this->filters['reception_id'])->select('id'));

--- a/app/Filament/Admin/Pages/Reports/ReceivablesReport.php
+++ b/app/Filament/Admin/Pages/Reports/ReceivablesReport.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Admin\Pages\Reports;
 
 use App\Exports\ReceivablesReportExport;
+use App\Helpers\DateHelper;
 use App\Models\Panel;
 use App\Models\Receaveable;
 use Filament\Forms\Components\DatePicker;
@@ -40,8 +41,8 @@ class ReceivablesReport extends Page implements Tables\Contracts\HasTable
     public function mount(): void
     {
         $this->filters = [
-            'from' => now()->startOfMonth()->format('Y-m-d'),
-            'until' => now()->format('Y-m-d'),
+            'from' => now(DateHelper::timezone())->startOfMonth()->format('Y-m-d'),
+            'until' => now(DateHelper::timezone())->format('Y-m-d'),
             'status' => null,
             'panel_id' => null,
         ];
@@ -88,10 +89,10 @@ class ReceivablesReport extends Page implements Tables\Contracts\HasTable
                     ]);
 
                 if ($this->filters['from'] ?? null) {
-                    $query->whereDate('receaveables.created_at', '>=', $this->filters['from']);
+                    $query->where('receaveables.created_at', '>=', DateHelper::dayStartUtc($this->filters['from']));
                 }
                 if ($this->filters['until'] ?? null) {
-                    $query->whereDate('receaveables.created_at', '<=', $this->filters['until']);
+                    $query->where('receaveables.created_at', '<=', DateHelper::dayEndUtc($this->filters['until']));
                 }
                 if ($this->filters['status'] ?? null) {
                     $query->where('status', $this->filters['status']);

--- a/app/Filament/Admin/Pages/Reports/ServicePerformanceReport.php
+++ b/app/Filament/Admin/Pages/Reports/ServicePerformanceReport.php
@@ -4,6 +4,7 @@ namespace App\Filament\Admin\Pages\Reports;
 
 use App\Enum\ServiceOrderStatus;
 use App\Exports\ServicePerformanceReportExport;
+use App\Helpers\DateHelper;
 use App\Models\Service;
 use App\Models\ServiceOrder;
 use App\Models\User;
@@ -43,8 +44,8 @@ class ServicePerformanceReport extends Page implements Tables\Contracts\HasTable
     public function mount(): void
     {
         $this->filters = [
-            'from' => now()->startOfMonth()->format('Y-m-d'),
-            'until' => now()->format('Y-m-d'),
+            'from' => now(DateHelper::timezone())->startOfMonth()->format('Y-m-d'),
+            'until' => now(DateHelper::timezone())->format('Y-m-d'),
             'type' => null,
             'status' => null,
             'service_id' => null,
@@ -112,8 +113,8 @@ class ServicePerformanceReport extends Page implements Tables\Contracts\HasTable
                     }], 'amount')
                     ->withSum(['expenseVouchers as voucher_total'], 'amount')
                     ->with(['patient:id,name', 'service:id,name', 'doctor:id,name'])
-                    ->when($this->filters['from'] ?? null, fn (Builder $q, $date) => $q->whereDate('service_orders.created_at', '>=', $date))
-                    ->when($this->filters['until'] ?? null, fn (Builder $q, $date) => $q->whereDate('service_orders.created_at', '<=', $date))
+                    ->when($this->filters['from'] ?? null, fn (Builder $q, $date) => $q->where('service_orders.created_at', '>=', DateHelper::dayStartUtc($date)))
+                    ->when($this->filters['until'] ?? null, fn (Builder $q, $date) => $q->where('service_orders.created_at', '<=', DateHelper::dayEndUtc($date)))
                     ->when($this->filters['type'] ?? null, fn (Builder $q, $type) => $q->where('type', $type))
                     ->when($this->filters['status'] ?? null, fn (Builder $q, $status) => $q->where('status', $status))
                     ->when($this->filters['service_id'] ?? null, fn (Builder $q, $id) => $q->where('service_id', $id))

--- a/app/Filament/Admin/Pages/Reports/ServiceProviderReport.php
+++ b/app/Filament/Admin/Pages/Reports/ServiceProviderReport.php
@@ -4,6 +4,7 @@ namespace App\Filament\Admin\Pages\Reports;
 
 use App\Enum\ServiceOrderStatus;
 use App\Exports\ServiceProviderReportExport;
+use App\Helpers\DateHelper;
 use App\Models\Service;
 use App\Models\ServiceOrder;
 use App\Models\User;
@@ -43,8 +44,8 @@ class ServiceProviderReport extends Page implements Tables\Contracts\HasTable
     public function mount(): void
     {
         $this->filters = [
-            'from' => now()->startOfMonth()->format('Y-m-d'),
-            'until' => now()->format('Y-m-d'),
+            'from' => now(DateHelper::timezone())->startOfMonth()->format('Y-m-d'),
+            'until' => now(DateHelper::timezone())->format('Y-m-d'),
             'doctor_id' => null,
             'service_id' => null,
             'status' => null,
@@ -103,8 +104,8 @@ class ServiceProviderReport extends Page implements Tables\Contracts\HasTable
                     }], 'amount')
                     ->withSum(['expenseVouchers as voucher_total'], 'amount')
                     ->with(['patient:id,name', 'service:id,name'])
-                    ->when($this->filters['from'] ?? null, fn (Builder $q, $date) => $q->whereDate('service_orders.created_at', '>=', $date))
-                    ->when($this->filters['until'] ?? null, fn (Builder $q, $date) => $q->whereDate('service_orders.created_at', '<=', $date))
+                    ->when($this->filters['from'] ?? null, fn (Builder $q, $date) => $q->where('service_orders.created_at', '>=', DateHelper::dayStartUtc($date)))
+                    ->when($this->filters['until'] ?? null, fn (Builder $q, $date) => $q->where('service_orders.created_at', '<=', DateHelper::dayEndUtc($date)))
                     ->when($this->filters['doctor_id'] ?? null, fn (Builder $q, $id) => $q->where('doctor_id', $id))
                     ->when($this->filters['service_id'] ?? null, fn (Builder $q, $id) => $q->where('service_id', $id))
                     ->when($this->filters['status'] ?? null, fn (Builder $q, $status) => $q->where('status', $status));

--- a/app/Filament/Admin/Pages/Reports/ServicesReport.php
+++ b/app/Filament/Admin/Pages/Reports/ServicesReport.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Admin\Pages\Reports;
 
 use App\Exports\ServicesReportExport;
+use App\Helpers\DateHelper;
 use App\Models\Closing;
 use App\Models\Reception;
 use App\Models\Service;
@@ -43,8 +44,8 @@ class ServicesReport extends Page implements Tables\Contracts\HasTable
     public function mount(): void
     {
         $this->filters = [
-            'from' => now()->startOfMonth()->format('Y-m-d'),
-            'until' => now()->format('Y-m-d'),
+            'from' => now(DateHelper::timezone())->startOfMonth()->format('Y-m-d'),
+            'until' => now(DateHelper::timezone())->format('Y-m-d'),
             'reception_id' => null,
             'income_or_expense' => null,
             'service_id' => null,
@@ -114,10 +115,10 @@ class ServicesReport extends Page implements Tables\Contracts\HasTable
                     ]);
 
                 if ($this->filters['from'] ?? null) {
-                    $query->whereDate('transaction_elements.created_at', '>=', $this->filters['from']);
+                    $query->where('transaction_elements.created_at', '>=', DateHelper::dayStartUtc($this->filters['from']));
                 }
                 if ($this->filters['until'] ?? null) {
-                    $query->whereDate('transaction_elements.created_at', '<=', $this->filters['until']);
+                    $query->where('transaction_elements.created_at', '<=', DateHelper::dayEndUtc($this->filters['until']));
                 }
                 if ($this->filters['reception_id'] ?? null) {
                     $query->whereIn('closing_id', Closing::where('reception_id', $this->filters['reception_id'])->select('id'));

--- a/app/Filament/Admin/Widgets/AdminStatsOverview.php
+++ b/app/Filament/Admin/Widgets/AdminStatsOverview.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Admin\Widgets;
 
 use App\Enum\CounterStatus;
+use App\Helpers\DateHelper;
 use App\Helpers\NumberHelper;
 use App\Models\Closing;
 use App\Models\ExpenseVoucher;
@@ -27,8 +28,10 @@ class AdminStatsOverview extends StatsOverviewWidget
 
     public function getStats(): array
     {
-        $startDate = $this->pageFilters['startDate'] ?? Carbon::now()->startOfMonth();
-        $endDate = $this->pageFilters['endDate'] ?? Carbon::now();
+        // Interpret the picked range in the hospital timezone, then resolve the
+        // exact UTC instants so datetime-column filters line up with stored data.
+        $startDate = DateHelper::dayStartUtc($this->pageFilters['startDate'] ?? Carbon::now(DateHelper::timezone())->startOfMonth());
+        $endDate = DateHelper::dayEndUtc($this->pageFilters['endDate'] ?? Carbon::now(DateHelper::timezone()));
 
         return [
             $this->getUserStats($startDate, $endDate),
@@ -50,14 +53,14 @@ class AdminStatsOverview extends StatsOverviewWidget
 
         $userThisDuration = User::query()
             ->nonSystem()
-            ->when($startDate, fn (Builder $query) => $query->whereDate('created_at', '>=', $startDate))
-            ->when($endDate, fn (Builder $query) => $query->whereDate('created_at', '<=', $endDate))
+            ->when($startDate, fn (Builder $query) => $query->where('created_at', '>=', $startDate))
+            ->when($endDate, fn (Builder $query) => $query->where('created_at', '<=', $endDate))
             ->count();
 
         $userChartThisDuration = User::query()
             ->nonSystem()
-            ->when($startDate, fn (Builder $query) => $query->whereDate('created_at', '>=', $startDate))
-            ->when($endDate, fn (Builder $query) => $query->whereDate('created_at', '<=', $endDate))
+            ->when($startDate, fn (Builder $query) => $query->where('created_at', '>=', $startDate))
+            ->when($endDate, fn (Builder $query) => $query->where('created_at', '<=', $endDate))
             ->selectRaw('DATE(created_at) as date, COUNT(*) as count')
             ->groupBy('date')
             ->orderBy('date')
@@ -78,13 +81,13 @@ class AdminStatsOverview extends StatsOverviewWidget
         $totalServices = Service::count();
 
         $serviceThisDuration = Service::query()
-            ->when($startDate, fn (Builder $query) => $query->whereDate('created_at', '>=', $startDate))
-            ->when($endDate, fn (Builder $query) => $query->whereDate('created_at', '<=', $endDate))
+            ->when($startDate, fn (Builder $query) => $query->where('created_at', '>=', $startDate))
+            ->when($endDate, fn (Builder $query) => $query->where('created_at', '<=', $endDate))
             ->count();
 
         $serviceChartThisDuration = Service::query()
-            ->when($startDate, fn (Builder $query) => $query->whereDate('created_at', '>=', $startDate))
-            ->when($endDate, fn (Builder $query) => $query->whereDate('created_at', '<=', $endDate))
+            ->when($startDate, fn (Builder $query) => $query->where('created_at', '>=', $startDate))
+            ->when($endDate, fn (Builder $query) => $query->where('created_at', '<=', $endDate))
             ->selectRaw('DATE(created_at) as date, COUNT(*) as count')
             ->groupBy('date')
             ->orderBy('date')
@@ -104,13 +107,13 @@ class AdminStatsOverview extends StatsOverviewWidget
         $totalPatients = Patient::count();
 
         $patientThisDuration = Patient::query()
-            ->when($startDate, fn (Builder $query) => $query->whereDate('created_at', '>=', $startDate))
-            ->when($endDate, fn (Builder $query) => $query->whereDate('created_at', '<=', $endDate))
+            ->when($startDate, fn (Builder $query) => $query->where('created_at', '>=', $startDate))
+            ->when($endDate, fn (Builder $query) => $query->where('created_at', '<=', $endDate))
             ->count();
 
         $patientChartThisDuration = Patient::query()
-            ->when($startDate, fn (Builder $query) => $query->whereDate('created_at', '>=', $startDate))
-            ->when($endDate, fn (Builder $query) => $query->whereDate('created_at', '<=', $endDate))
+            ->when($startDate, fn (Builder $query) => $query->where('created_at', '>=', $startDate))
+            ->when($endDate, fn (Builder $query) => $query->where('created_at', '<=', $endDate))
             ->selectRaw('DATE(created_at) as date, COUNT(*) as count')
             ->groupBy('date')
             ->orderBy('date')
@@ -136,21 +139,21 @@ class AdminStatsOverview extends StatsOverviewWidget
         $receptions = Reception::count();
 
         $periodTotals = Closing::query()
-            ->when($startDate, fn (Builder $query) => $query->whereDate('created_at', '>=', $startDate))
-            ->when($endDate, fn (Builder $query) => $query->whereDate('created_at', '<=', $endDate))
+            ->when($startDate, fn (Builder $query) => $query->where('created_at', '>=', $startDate))
+            ->when($endDate, fn (Builder $query) => $query->where('created_at', '<=', $endDate))
             ->selectRaw('SUM(closing_amount) - SUM(opening_amount) as net, COUNT(*) as total_closings')
             ->first();
         $totalCollectionThisDuration = $periodTotals->net ?? 0;
         $totalClosingsThisDuration = $periodTotals->total_closings ?? 0;
         $totalOpeningsThisDuration = Closing::query()
-            ->when($startDate, fn (Builder $query) => $query->whereDate('created_at', '>=', $startDate))
-            ->when($endDate, fn (Builder $query) => $query->whereDate('created_at', '<=', $endDate))
+            ->when($startDate, fn (Builder $query) => $query->where('created_at', '>=', $startDate))
+            ->when($endDate, fn (Builder $query) => $query->where('created_at', '<=', $endDate))
             ->where('status', CounterStatus::OPEN)
             ->count();
 
         $totalChartThisDuration = Closing::query()
-            ->when($startDate, fn (Builder $query) => $query->whereDate('created_at', '>=', $startDate))
-            ->when($endDate, fn (Builder $query) => $query->whereDate('created_at', '<=', $endDate))
+            ->when($startDate, fn (Builder $query) => $query->where('created_at', '>=', $startDate))
+            ->when($endDate, fn (Builder $query) => $query->where('created_at', '<=', $endDate))
             ->selectRaw('DATE(created_at) as date, SUM(closing_amount) as count')
             ->groupBy('date')
             ->orderBy('date')
@@ -171,18 +174,18 @@ class AdminStatsOverview extends StatsOverviewWidget
         $total = ExpenseVoucher::count();
 
         $expenseThisDuration = ExpenseVoucher::query()
-            ->when($startDate, fn (Builder $query) => $query->whereDate('created_at', '>=', $startDate))
-            ->when($endDate, fn (Builder $query) => $query->whereDate('created_at', '<=', $endDate))
+            ->when($startDate, fn (Builder $query) => $query->where('created_at', '>=', $startDate))
+            ->when($endDate, fn (Builder $query) => $query->where('created_at', '<=', $endDate))
             ->sum('amount');
 
         $totalThisDuration = ExpenseVoucher::query()
-            ->when($startDate, fn (Builder $query) => $query->whereDate('created_at', '>=', $startDate))
-            ->when($endDate, fn (Builder $query) => $query->whereDate('created_at', '<=', $endDate))
+            ->when($startDate, fn (Builder $query) => $query->where('created_at', '>=', $startDate))
+            ->when($endDate, fn (Builder $query) => $query->where('created_at', '<=', $endDate))
             ->count();
 
         $expenseChartThisDuration = ExpenseVoucher::query()
-            ->when($startDate, fn (Builder $query) => $query->whereDate('created_at', '>=', $startDate))
-            ->when($endDate, fn (Builder $query) => $query->whereDate('created_at', '<=', $endDate))
+            ->when($startDate, fn (Builder $query) => $query->where('created_at', '>=', $startDate))
+            ->when($endDate, fn (Builder $query) => $query->where('created_at', '<=', $endDate))
             ->selectRaw('DATE(created_at) as date, COUNT(*) as count')
             ->groupBy('date')
             ->orderBy('date')
@@ -203,17 +206,17 @@ class AdminStatsOverview extends StatsOverviewWidget
         $total = Transaction::count();
 
         $totalCollectionThisDuration = Transaction::query()
-            ->when($startDate, fn (Builder $query) => $query->whereDate('created_at', '>=', $startDate))
-            ->when($endDate, fn (Builder $query) => $query->whereDate('created_at', '<=', $endDate))
+            ->when($startDate, fn (Builder $query) => $query->where('created_at', '>=', $startDate))
+            ->when($endDate, fn (Builder $query) => $query->where('created_at', '<=', $endDate))
             ->sum('amount');
         $totalThisDuration = Transaction::query()
-            ->when($startDate, fn (Builder $query) => $query->whereDate('created_at', '>=', $startDate))
-            ->when($endDate, fn (Builder $query) => $query->whereDate('created_at', '<=', $endDate))
+            ->when($startDate, fn (Builder $query) => $query->where('created_at', '>=', $startDate))
+            ->when($endDate, fn (Builder $query) => $query->where('created_at', '<=', $endDate))
             ->count();
 
         $totalChartThisDuration = Transaction::query()
-            ->when($startDate, fn (Builder $query) => $query->whereDate('created_at', '>=', $startDate))
-            ->when($endDate, fn (Builder $query) => $query->whereDate('created_at', '<=', $endDate))
+            ->when($startDate, fn (Builder $query) => $query->where('created_at', '>=', $startDate))
+            ->when($endDate, fn (Builder $query) => $query->where('created_at', '<=', $endDate))
             ->selectRaw('DATE(created_at) as date, SUM(amount) as count')
             ->groupBy('date')
             ->orderBy('date')

--- a/app/Helpers/DateHelper.php
+++ b/app/Helpers/DateHelper.php
@@ -36,6 +36,58 @@ class DateHelper
         return $carbon->setTimezone(self::timezone());
     }
 
+    /**
+     * Resolve the UTC instant for the START of a day that the user picked in the
+     * hospital timezone. Use for the lower bound of a datetime-column filter.
+     *
+     * A bare date string is interpreted in the hospital timezone (not UTC), so
+     * "2026-05-23" becomes 2026-05-22 19:00:00 UTC for Asia/Karachi (+05:00).
+     */
+    public static function dayStartUtc(mixed $date): ?CarbonInterface
+    {
+        return self::inHospitalTimezone($date)?->startOfDay()->utc();
+    }
+
+    /**
+     * Resolve the UTC instant for the END of a day that the user picked in the
+     * hospital timezone. Use for the (inclusive) upper bound of a datetime-column
+     * filter.
+     */
+    public static function dayEndUtc(mixed $date): ?CarbonInterface
+    {
+        return self::inHospitalTimezone($date)?->endOfDay()->utc();
+    }
+
+    /**
+     * UTC range [start, end] covering "today" as seen in the hospital timezone.
+     * Use with whereBetween on a datetime column to scope a query to today.
+     *
+     * @return array{0: CarbonInterface, 1: CarbonInterface}
+     */
+    public static function todayRangeUtc(): array
+    {
+        $today = Carbon::now(self::timezone());
+
+        return [self::dayStartUtc($today), self::dayEndUtc($today)];
+    }
+
+    /**
+     * Interpret a filter value as a moment in the hospital timezone.
+     *
+     * Strings are parsed AS hospital-local time (the user picked them in their
+     * own timezone); existing Carbon instances are converted into it.
+     */
+    private static function inHospitalTimezone(mixed $date): ?CarbonInterface
+    {
+        if ($date === null || $date === '') {
+            return null;
+        }
+
+        return $date instanceof CarbonInterface
+            ? $date->copy()->setTimezone(self::timezone())
+            : Carbon::parse($date, self::timezone());
+    }
+
     public static function pdfFormat(mixed $date, string $format): string
     {
         $converted = self::tz($date);

--- a/app/Http/Controllers/Api/ExpenseVoucherController.php
+++ b/app/Http/Controllers/Api/ExpenseVoucherController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\Helpers\DateHelper;
 use App\Http\Controllers\Controller;
 use App\Models\ExpenseVoucher;
 use Illuminate\Http\Request;
@@ -60,11 +61,11 @@ class ExpenseVoucherController extends Controller
         }
 
         if (! empty($filters['created_from'])) {
-            $query->whereDate('created_at', '>=', $filters['created_from']);
+            $query->where('created_at', '>=', DateHelper::dayStartUtc($filters['created_from']));
         }
 
         if (! empty($filters['created_to'])) {
-            $query->whereDate('created_at', '<=', $filters['created_to']);
+            $query->where('created_at', '<=', DateHelper::dayEndUtc($filters['created_to']));
         }
 
         $exact = collect();

--- a/app/Http/Controllers/Api/OpdController.php
+++ b/app/Http/Controllers/Api/OpdController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\Helpers\DateHelper;
 use App\Http\Controllers\Controller;
 use App\Models\Icd10Code;
 use App\Models\Patient;
@@ -217,7 +218,7 @@ class OpdController extends Controller
             ->with(['patient:id,name,ps_number,gender,age_days,age_dob', 'service:id,name', 'treatmentRecord:id,service_order_id,is_finalized,diagnosis_text'])
             ->where('type', 'OPD')
             ->where('doctor_id', $user->id)
-            ->whereDate('created_at', Carbon::today())
+            ->whereBetween('created_at', DateHelper::todayRangeUtc())
             ->orderByRaw("FIELD(status, 'in-progress', 'IN-PROGRESS', 'open', 'OPEN', 'treated', 'TREATED') ASC")
             ->orderBy('created_at', 'ASC')
             ->get();

--- a/app/Http/Controllers/Api/ServiceOrderController.php
+++ b/app/Http/Controllers/Api/ServiceOrderController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\Helpers\DateHelper;
 use App\Http\Controllers\Controller;
 use App\Models\ServiceOrder;
 use Illuminate\Http\Request;
@@ -51,11 +52,11 @@ class ServiceOrderController extends Controller
         }
 
         if (! empty($filters['created_from'])) {
-            $query->whereDate('created_at', '>=', $filters['created_from']);
+            $query->where('created_at', '>=', DateHelper::dayStartUtc($filters['created_from']));
         }
 
         if (! empty($filters['created_to'])) {
-            $query->whereDate('created_at', '<=', $filters['created_to']);
+            $query->where('created_at', '<=', DateHelper::dayEndUtc($filters['created_to']));
         }
 
         $exact = collect();

--- a/app/Http/Controllers/Api/TransactionController.php
+++ b/app/Http/Controllers/Api/TransactionController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\Helpers\DateHelper;
 use App\Http\Controllers\Controller;
 use App\Models\Transaction;
 use Illuminate\Http\Request;
@@ -53,11 +54,11 @@ class TransactionController extends Controller
         }
 
         if (! empty($filters['created_from'])) {
-            $query->whereDate('created_at', '>=', $filters['created_from']);
+            $query->where('created_at', '>=', DateHelper::dayStartUtc($filters['created_from']));
         }
 
         if (! empty($filters['created_to'])) {
-            $query->whereDate('created_at', '<=', $filters['created_to']);
+            $query->where('created_at', '<=', DateHelper::dayEndUtc($filters['created_to']));
         }
 
         $exact = collect();

--- a/app/Http/Controllers/DentistController.php
+++ b/app/Http/Controllers/DentistController.php
@@ -2,10 +2,10 @@
 
 namespace App\Http\Controllers;
 
+use App\Helpers\DateHelper;
 use App\Models\Patient;
 use App\Models\ServiceOrder;
 use Illuminate\Http\Request;
-use Illuminate\Support\Carbon;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -24,7 +24,7 @@ class DentistController extends Controller
                 ->with(['patient:id,name,ps_number,gender,age_days,age_dob', 'service:id,name', 'treatmentRecord:id,service_order_id,is_finalized,diagnosis_text'])
                 ->where('type', 'DNT')
                 ->where('doctor_id', $user->id)
-                ->whereDate('created_at', Carbon::today())
+                ->whereBetween('created_at', DateHelper::todayRangeUtc())
                 ->orderByRaw("FIELD(status, 'in-progress', 'IN-PROGRESS', 'open', 'OPEN', 'treated', 'TREATED') ASC")
                 ->orderBy('created_at', 'ASC')
                 ->limit(30)

--- a/app/Http/Controllers/EmergencyDoctorController.php
+++ b/app/Http/Controllers/EmergencyDoctorController.php
@@ -2,10 +2,10 @@
 
 namespace App\Http\Controllers;
 
+use App\Helpers\DateHelper;
 use App\Models\Patient;
 use App\Models\ServiceOrder;
 use Illuminate\Http\Request;
-use Illuminate\Support\Carbon;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -24,7 +24,7 @@ class EmergencyDoctorController extends Controller
                 ->with(['patient:id,name,ps_number,gender,age_days,age_dob', 'service:id,name', 'treatmentRecord:id,service_order_id,is_finalized,diagnosis_text'])
                 ->where('type', 'EMG')
                 ->where('doctor_id', $user->id)
-                ->whereDate('created_at', Carbon::today())
+                ->whereBetween('created_at', DateHelper::todayRangeUtc())
                 ->orderByRaw("FIELD(status, 'in-progress', 'IN-PROGRESS', 'open', 'OPEN', 'treated', 'TREATED') ASC")
                 ->orderBy('created_at', 'ASC')
                 ->limit(30)

--- a/app/Http/Controllers/LabController.php
+++ b/app/Http/Controllers/LabController.php
@@ -2,10 +2,10 @@
 
 namespace App\Http\Controllers;
 
+use App\Helpers\DateHelper;
 use App\Models\Patient;
 use App\Models\ServiceOrder;
 use Illuminate\Http\Request;
-use Illuminate\Support\Carbon;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -25,7 +25,7 @@ class LabController extends Controller
             $recentOrders = ServiceOrder::query()
                 ->with(['patient:id,name,ps_number,gender,age_days,age_dob', 'service:id,name', 'treatmentRecord:id,service_order_id,is_finalized,diagnosis_text'])
                 ->where('type', 'PTH')
-                ->whereDate('created_at', Carbon::today())
+                ->whereBetween('created_at', DateHelper::todayRangeUtc())
                 ->orderByRaw("FIELD(status, 'in-progress', 'IN-PROGRESS', 'open', 'OPEN', 'treated', 'TREATED') ASC")
                 ->orderBy('created_at', 'ASC')
                 ->limit(50)

--- a/app/Http/Controllers/OpdDoctorController.php
+++ b/app/Http/Controllers/OpdDoctorController.php
@@ -2,10 +2,10 @@
 
 namespace App\Http\Controllers;
 
+use App\Helpers\DateHelper;
 use App\Models\Patient;
 use App\Models\ServiceOrder;
 use Illuminate\Http\Request;
-use Illuminate\Support\Carbon;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -27,7 +27,7 @@ class OpdDoctorController extends Controller
                 ->with(['patient:id,name,ps_number,gender,age_days,age_dob', 'service:id,name', 'treatmentRecord:id,service_order_id,is_finalized,diagnosis_text'])
                 ->where('type', 'OPD')
                 ->where('doctor_id', $user->id)
-                ->whereDate('created_at', Carbon::today())
+                ->whereBetween('created_at', DateHelper::todayRangeUtc())
                 ->orderByRaw("FIELD(status, 'in-progress', 'IN-PROGRESS', 'open', 'OPEN', 'treated', 'TREATED') ASC")
                 ->orderBy('created_at', 'ASC')
                 ->limit(30)

--- a/app/Http/Controllers/Reports/BankPaymentReportController.php
+++ b/app/Http/Controllers/Reports/BankPaymentReportController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Reports;
 
+use App\Helpers\DateHelper;
 use App\Http\Controllers\Controller;
 use App\Models\BankTransaction;
 use Barryvdh\DomPDF\Facade\Pdf;
@@ -14,8 +15,8 @@ class BankPaymentReportController extends Controller
     public function pending(Request $request): Response
     {
         $bankAccountId = $request->input('bank_account_id');
-        $from = Carbon::parse($request->input('date_from', now()->startOfMonth()->format('Y-m-d')))->startOfDay();
-        $until = Carbon::parse($request->input('date_to', now()->endOfMonth()->format('Y-m-d')))->endOfDay();
+        $from = Carbon::parse($request->input('date_from', now(DateHelper::timezone())->startOfMonth()->format('Y-m-d')))->startOfDay();
+        $until = Carbon::parse($request->input('date_to', now(DateHelper::timezone())->endOfMonth()->format('Y-m-d')))->endOfDay();
         $generated_at = now();
 
         $query = BankTransaction::query()
@@ -45,8 +46,8 @@ class BankPaymentReportController extends Controller
     public function received(Request $request): Response
     {
         $bankAccountId = $request->input('bank_account_id');
-        $from = Carbon::parse($request->input('date_from', now()->startOfMonth()->format('Y-m-d')))->startOfDay();
-        $until = Carbon::parse($request->input('date_to', now()->endOfMonth()->format('Y-m-d')))->endOfDay();
+        $from = Carbon::parse($request->input('date_from', now(DateHelper::timezone())->startOfMonth()->format('Y-m-d')))->startOfDay();
+        $until = Carbon::parse($request->input('date_to', now(DateHelper::timezone())->endOfMonth()->format('Y-m-d')))->endOfDay();
         $generated_at = now();
 
         $query = BankTransaction::query()

--- a/app/Http/Controllers/Reports/GenericReportPdfController.php
+++ b/app/Http/Controllers/Reports/GenericReportPdfController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Reports;
 
+use App\Helpers\DateHelper;
 use App\Http\Controllers\Controller;
 use App\Models\Closing;
 use App\Models\Receaveable;
@@ -20,13 +21,12 @@ class GenericReportPdfController extends Controller
 {
     public function income(Request $request): Response
     {
-        $from = $request->date('from') ?? now()->startOfMonth();
-        $until = $request->date('until') ?? now();
+        [$from, $until] = $this->resolveDateRange($request);
 
         $query = TransactionElement::query()
             ->where('income_or_expense', 'INCOME')
-            ->whereDate('transaction_elements.created_at', '>=', $from)
-            ->whereDate('transaction_elements.created_at', '<=', $until)
+            ->where('transaction_elements.created_at', '>=', DateHelper::dayStartUtc($from))
+            ->where('transaction_elements.created_at', '<=', DateHelper::dayEndUtc($until))
             ->with(['transaction.closing.reception', 'patient', 'service', 'doctor']);
 
         if ($request->filled('reception_id')) {
@@ -53,8 +53,8 @@ class GenericReportPdfController extends Controller
             'elements' => $elements,
             'total' => $total,
             'by_type' => $byType,
-            'from' => Carbon::parse($from),
-            'until' => Carbon::parse($until),
+            'from' => $from,
+            'until' => $until,
             'generated_at' => now(),
             'filters' => $this->describeFilters($request, ['reception_id', 'type', 'service_id', 'doctor_id']),
         ], 'income-report');
@@ -62,13 +62,12 @@ class GenericReportPdfController extends Controller
 
     public function expense(Request $request): Response
     {
-        $from = $request->date('from') ?? now()->startOfMonth();
-        $until = $request->date('until') ?? now();
+        [$from, $until] = $this->resolveDateRange($request);
 
         $query = TransactionElement::query()
             ->where('income_or_expense', 'EXPENSE')
-            ->whereDate('transaction_elements.created_at', '>=', $from)
-            ->whereDate('transaction_elements.created_at', '<=', $until)
+            ->where('transaction_elements.created_at', '>=', DateHelper::dayStartUtc($from))
+            ->where('transaction_elements.created_at', '<=', DateHelper::dayEndUtc($until))
             ->with(['transaction.closing.reception', 'expenseCategory', 'expVoucher.payedTo', 'expVoucher.expCategory']);
 
         if ($request->filled('reception_id')) {
@@ -87,8 +86,8 @@ class GenericReportPdfController extends Controller
         return $this->renderPdf('pdfs.reports.generic-expense', [
             'elements' => $elements,
             'total' => $total,
-            'from' => Carbon::parse($from),
-            'until' => Carbon::parse($until),
+            'from' => $from,
+            'until' => $until,
             'generated_at' => now(),
             'filters' => $this->describeFilters($request, ['reception_id', 'type', 'expense_category_id']),
         ], 'expense-report');
@@ -96,12 +95,11 @@ class GenericReportPdfController extends Controller
 
     public function receivables(Request $request): Response
     {
-        $from = $request->date('from') ?? now()->startOfMonth();
-        $until = $request->date('until') ?? now();
+        [$from, $until] = $this->resolveDateRange($request);
 
         $query = Receaveable::query()
-            ->whereDate('receaveables.created_at', '>=', $from)
-            ->whereDate('receaveables.created_at', '<=', $until)
+            ->where('receaveables.created_at', '>=', DateHelper::dayStartUtc($from))
+            ->where('receaveables.created_at', '<=', DateHelper::dayEndUtc($until))
             ->with(['patient', 'panel', 'transaction']);
 
         if ($request->filled('status')) {
@@ -117,8 +115,8 @@ class GenericReportPdfController extends Controller
         return $this->renderPdf('pdfs.reports.generic-receivables', [
             'items' => $items,
             'total' => $total,
-            'from' => Carbon::parse($from),
-            'until' => Carbon::parse($until),
+            'from' => $from,
+            'until' => $until,
             'generated_at' => now(),
             'filters' => $this->describeFilters($request, ['status', 'panel_id']),
         ], 'receivables-report');
@@ -126,15 +124,14 @@ class GenericReportPdfController extends Controller
 
     public function services(Request $request): Response
     {
-        $from = $request->date('from') ?? now()->startOfMonth();
-        $until = $request->date('until') ?? now();
+        [$from, $until] = $this->resolveDateRange($request);
 
         // Income elements with services
         $incomeQuery = TransactionElement::query()
             ->whereNotNull('service_id')
             ->where('income_or_expense', 'INCOME')
-            ->whereDate('transaction_elements.created_at', '>=', $from)
-            ->whereDate('transaction_elements.created_at', '<=', $until)
+            ->where('transaction_elements.created_at', '>=', DateHelper::dayStartUtc($from))
+            ->where('transaction_elements.created_at', '<=', DateHelper::dayEndUtc($until))
             ->with(['transaction', 'patient', 'service.department', 'doctor']);
 
         if ($request->filled('reception_id')) {
@@ -152,8 +149,8 @@ class GenericReportPdfController extends Controller
         // Expense elements (voucher payments to providers) within span
         $expenseQuery = TransactionElement::query()
             ->where('income_or_expense', 'EXPENSE')
-            ->whereDate('transaction_elements.created_at', '>=', $from)
-            ->whereDate('transaction_elements.created_at', '<=', $until)
+            ->where('transaction_elements.created_at', '>=', DateHelper::dayStartUtc($from))
+            ->where('transaction_elements.created_at', '<=', DateHelper::dayEndUtc($until))
             ->whereNotNull('exp_voucher_id')
             ->with(['expVoucher.payedTo', 'expVoucher.expCategory', 'expenseCategory']);
 
@@ -248,8 +245,8 @@ class GenericReportPdfController extends Controller
             'expenses_by_doctor' => array_values($expensesByDoctor),
             'total_service_income' => $totalServiceIncome,
             'total_expense_paid' => $totalExpensePaid,
-            'from' => Carbon::parse($from),
-            'until' => Carbon::parse($until),
+            'from' => $from,
+            'until' => $until,
             'generated_at' => now(),
             'filters' => $this->describeFilters($request, ['reception_id', 'service_id', 'doctor_id']),
         ], 'services-report');
@@ -257,12 +254,11 @@ class GenericReportPdfController extends Controller
 
     public function serviceOrders(Request $request): Response
     {
-        $from = $request->date('from') ?? now()->startOfMonth();
-        $until = $request->date('until') ?? now();
+        [$from, $until] = $this->resolveDateRange($request);
 
         $query = ServiceOrder::query()
-            ->whereDate('service_orders.created_at', '>=', $from)
-            ->whereDate('service_orders.created_at', '<=', $until)
+            ->where('service_orders.created_at', '>=', DateHelper::dayStartUtc($from))
+            ->where('service_orders.created_at', '<=', DateHelper::dayEndUtc($until))
             ->with(['patient:id,name', 'service:id,name', 'doctor:id,name', 'expenseVouchers'])
             ->withSum(['transactionElements as income_total' => fn ($q) => $q->where('income_or_expense', 'INCOME')], 'amount')
             ->withSum(['expenseVouchers as voucher_total'], 'amount')
@@ -282,8 +278,8 @@ class GenericReportPdfController extends Controller
 
         return $this->renderPdf('pdfs.reports.generic-service-orders', [
             'orders' => $orders,
-            'from' => Carbon::parse($from),
-            'until' => Carbon::parse($until),
+            'from' => $from,
+            'until' => $until,
             'generated_at' => now(),
         ], 'service-orders-report');
     }
@@ -349,6 +345,28 @@ class GenericReportPdfController extends Controller
         }
     }
 
+    /**
+     * Resolve the requested [from, until] range as hospital-timezone Carbon
+     * instances. User-supplied dates are interpreted in the hospital timezone,
+     * and defaults span the current month in that same timezone.
+     *
+     * @return array{0: Carbon, 1: Carbon}
+     */
+    private function resolveDateRange(Request $request): array
+    {
+        $timezone = DateHelper::timezone();
+
+        $from = $request->filled('from')
+            ? Carbon::parse($request->input('from'), $timezone)
+            : now($timezone)->startOfMonth();
+
+        $until = $request->filled('until')
+            ? Carbon::parse($request->input('until'), $timezone)
+            : now($timezone);
+
+        return [$from, $until];
+    }
+
     private function describeFilters(Request $request, array $keys): array
     {
         $filters = [];
@@ -363,12 +381,11 @@ class GenericReportPdfController extends Controller
 
     public function servicePerformance(Request $request): Response
     {
-        $from = $request->date('from') ?? now()->startOfMonth();
-        $until = $request->date('until') ?? now();
+        [$from, $until] = $this->resolveDateRange($request);
 
         $query = ServiceOrder::query()
-            ->whereDate('service_orders.created_at', '>=', $from)
-            ->whereDate('service_orders.created_at', '<=', $until)
+            ->where('service_orders.created_at', '>=', DateHelper::dayStartUtc($from))
+            ->where('service_orders.created_at', '<=', DateHelper::dayEndUtc($until))
             ->with(['patient:id,name', 'service:id,name', 'doctor:id,name'])
             ->withSum(['transactionElements as income_total' => fn ($q) => $q->where('income_or_expense', 'INCOME')], 'amount')
             ->withSum('expenseVouchers as voucher_total', 'amount');
@@ -403,8 +420,8 @@ class GenericReportPdfController extends Controller
             'total_income' => $totalIncome,
             'total_expense' => $totalExpense,
             'by_department' => $byDepartment,
-            'from' => Carbon::parse($from),
-            'until' => Carbon::parse($until),
+            'from' => $from,
+            'until' => $until,
             'generated_at' => now(),
             'filters' => $this->describeFilters($request, ['type', 'status', 'service_id', 'doctor_id']),
         ], 'service-performance-report');
@@ -412,12 +429,11 @@ class GenericReportPdfController extends Controller
 
     public function serviceProvider(Request $request): Response
     {
-        $from = $request->date('from') ?? now()->startOfMonth();
-        $until = $request->date('until') ?? now();
+        [$from, $until] = $this->resolveDateRange($request);
 
         $query = ServiceOrder::query()
-            ->whereDate('service_orders.created_at', '>=', $from)
-            ->whereDate('service_orders.created_at', '<=', $until)
+            ->where('service_orders.created_at', '>=', DateHelper::dayStartUtc($from))
+            ->where('service_orders.created_at', '<=', DateHelper::dayEndUtc($until))
             ->with(['patient:id,name', 'service:id,name', 'doctor:id,name', 'expenseVouchers.expCategory'])
             ->withSum(['transactionElements as income_total' => fn ($q) => $q->where('income_or_expense', 'INCOME')], 'amount')
             ->withSum('expenseVouchers as voucher_total', 'amount');
@@ -446,8 +462,8 @@ class GenericReportPdfController extends Controller
             'provider' => $provider,
             'total_income' => $totalIncome,
             'total_expense' => $totalExpense,
-            'from' => Carbon::parse($from),
-            'until' => Carbon::parse($until),
+            'from' => $from,
+            'until' => $until,
             'generated_at' => now(),
             'filters' => $this->describeFilters($request, ['doctor_id', 'service_id', 'status']),
         ], 'service-provider-report');

--- a/app/Http/Controllers/Reports/IncomeCashFlowReportController.php
+++ b/app/Http/Controllers/Reports/IncomeCashFlowReportController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Reports;
 
+use App\Helpers\DateHelper;
 use App\Http\Controllers\Controller;
 use App\Models\Closing;
 use App\Models\Patient;
@@ -9,7 +10,6 @@ use App\Models\Service;
 use App\Models\TransactionElement;
 use App\Models\User;
 use Barryvdh\DomPDF\Facade\Pdf;
-use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -31,8 +31,8 @@ class IncomeCashFlowReportController extends Controller
         gc_enable();
 
         // Get filters from request
-        $dateFrom = $request->input('date_from', now()->startOfMonth()->format('Y-m-d'));
-        $dateTo = $request->input('date_to', now()->endOfMonth()->format('Y-m-d'));
+        $dateFrom = $request->input('date_from', now(DateHelper::timezone())->startOfMonth()->format('Y-m-d'));
+        $dateTo = $request->input('date_to', now(DateHelper::timezone())->endOfMonth()->format('Y-m-d'));
         $closingId = $request->input('closing_id');
         $serviceId = $request->input('service_id');
         $serviceOrderId = $request->input('service_order_id');
@@ -66,8 +66,8 @@ class IncomeCashFlowReportController extends Controller
             ->where('income_or_expense', 'INCOME')
             ->when($dateFrom && $dateTo, function ($q) use ($dateFrom, $dateTo) {
                 return $q->whereBetween('created_at', [
-                    Carbon::parse($dateFrom)->startOfDay(),
-                    Carbon::parse($dateTo)->endOfDay(),
+                    DateHelper::dayStartUtc($dateFrom),
+                    DateHelper::dayEndUtc($dateTo),
                 ]);
             })
             ->when($closingId, fn ($q) => $q->where('closing_id', $closingId))
@@ -159,7 +159,7 @@ class IncomeCashFlowReportController extends Controller
             'filters' => $filterData,
             'group_by' => $groupBy,
             'columns' => $columns,
-            'generated_at' => now()->format('M d, Y H:i:s'),
+            'generated_at' => DateHelper::pdfFormat(now(), 'M d, Y H:i:s'),
             'total_records_in_db' => $totalCount,
             'records_shown' => $processedCount,
         ];
@@ -273,8 +273,8 @@ class IncomeCashFlowReportController extends Controller
         // Apply date filter
         if ($dateFrom && $dateTo) {
             $query->whereBetween('transaction_elements.created_at', [
-                Carbon::parse($dateFrom)->startOfDay(),
-                Carbon::parse($dateTo)->endOfDay(),
+                DateHelper::dayStartUtc($dateFrom),
+                DateHelper::dayEndUtc($dateTo),
             ]);
         }
 
@@ -334,8 +334,8 @@ class IncomeCashFlowReportController extends Controller
                 break;
 
             case 'date':
-                $key = Carbon::parse($element->created_at)->format('Y-m-d');
-                $label = Carbon::parse($element->created_at)->format('M d, Y');
+                $key = DateHelper::tz($element->created_at)->format('Y-m-d');
+                $label = DateHelper::tz($element->created_at)->format('M d, Y');
                 break;
 
             default:

--- a/app/Http/Controllers/Reports/PanelPaymentReportController.php
+++ b/app/Http/Controllers/Reports/PanelPaymentReportController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Reports;
 
+use App\Helpers\DateHelper;
 use App\Http\Controllers\Controller;
 use App\Models\Panel;
 use App\Models\PanelCheque;
@@ -15,14 +16,19 @@ class PanelPaymentReportController extends Controller
     public function pending(Request $request): Response
     {
         $panelId = $request->input('panel_id');
-        $from = Carbon::parse($request->input('date_from', now()->startOfMonth()->format('Y-m-d')))->startOfDay();
-        $until = Carbon::parse($request->input('date_to', now()->endOfMonth()->format('Y-m-d')))->endOfDay();
+        $timezone = DateHelper::timezone();
+        $from = $request->filled('date_from')
+            ? Carbon::parse($request->input('date_from'), $timezone)
+            : now($timezone)->startOfMonth();
+        $until = $request->filled('date_to')
+            ? Carbon::parse($request->input('date_to'), $timezone)
+            : now($timezone)->endOfMonth();
         $generated_at = now();
 
         $query = PanelCheque::query()
             ->with(['panel', 'bankAccount'])
             ->where('status', 'pending')
-            ->whereBetween('created_at', [$from, $until]);
+            ->whereBetween('created_at', [DateHelper::dayStartUtc($from), DateHelper::dayEndUtc($until)]);
 
         if ($panelId) {
             $query->where('panel_id', $panelId);

--- a/app/Http/Controllers/UltrasoundController.php
+++ b/app/Http/Controllers/UltrasoundController.php
@@ -2,10 +2,10 @@
 
 namespace App\Http\Controllers;
 
+use App\Helpers\DateHelper;
 use App\Models\Patient;
 use App\Models\ServiceOrder;
 use Illuminate\Http\Request;
-use Illuminate\Support\Carbon;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -24,7 +24,7 @@ class UltrasoundController extends Controller
                 ->with(['patient:id,name,ps_number,gender,age_days,age_dob', 'service:id,name', 'treatmentRecord:id,service_order_id,is_finalized,diagnosis_text'])
                 ->where('type', 'ULT')
                 ->where('doctor_id', $user->id)
-                ->whereDate('created_at', Carbon::today())
+                ->whereBetween('created_at', DateHelper::todayRangeUtc())
                 ->orderByRaw("FIELD(status, 'in-progress', 'IN-PROGRESS', 'open', 'OPEN', 'treated', 'TREATED') ASC")
                 ->orderBy('created_at', 'ASC')
                 ->limit(30)

--- a/app/Http/Controllers/WebController.php
+++ b/app/Http/Controllers/WebController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Enum\CounterStatus;
 use App\Enum\TransactionElementType;
+use App\Helpers\DateHelper;
 use App\Models\Closing;
 use App\Models\ExpenseCategory;
 use App\Models\ExpenseVoucher;
@@ -124,7 +125,7 @@ class WebController extends Controller
             ->pluck('total', 'status');
 
         $today = (clone $base)
-            ->whereDate('created_at', now()->toDateString())
+            ->whereBetween('created_at', DateHelper::todayRangeUtc())
             ->count();
 
         $recent = (clone $base)
@@ -185,10 +186,10 @@ class WebController extends Controller
             });
         }
         if (! empty($filters['from'])) {
-            $query->whereDate('created_at', '>=', $filters['from']);
+            $query->where('created_at', '>=', DateHelper::dayStartUtc($filters['from']));
         }
         if (! empty($filters['until'])) {
-            $query->whereDate('created_at', '<=', $filters['until']);
+            $query->where('created_at', '<=', DateHelper::dayEndUtc($filters['until']));
         }
 
         $orders = $query->latest('id')->paginate(20)->withQueryString();
@@ -235,10 +236,10 @@ class WebController extends Controller
             });
         }
         if (! empty($filters['from'])) {
-            $query->whereDate('created_at', '>=', $filters['from']);
+            $query->where('created_at', '>=', DateHelper::dayStartUtc($filters['from']));
         }
         if (! empty($filters['until'])) {
-            $query->whereDate('created_at', '<=', $filters['until']);
+            $query->where('created_at', '<=', DateHelper::dayEndUtc($filters['until']));
         }
 
         $vouchers = $query->latest('id')->paginate(20)->withQueryString();

--- a/app/Http/Controllers/XrayController.php
+++ b/app/Http/Controllers/XrayController.php
@@ -2,10 +2,10 @@
 
 namespace App\Http\Controllers;
 
+use App\Helpers\DateHelper;
 use App\Models\Patient;
 use App\Models\ServiceOrder;
 use Illuminate\Http\Request;
-use Illuminate\Support\Carbon;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -24,7 +24,7 @@ class XrayController extends Controller
                 ->with(['patient:id,name,ps_number,gender,age_days,age_dob', 'service:id,name', 'treatmentRecord:id,service_order_id,is_finalized,diagnosis_text'])
                 ->whereIn('type', ['XRAY', 'RAD'])
                 ->where('doctor_id', $user->id)
-                ->whereDate('created_at', Carbon::today())
+                ->whereBetween('created_at', DateHelper::todayRangeUtc())
                 ->orderByRaw("FIELD(status, 'in-progress', 'IN-PROGRESS', 'open', 'OPEN', 'treated', 'TREATED') ASC")
                 ->orderBy('created_at', 'ASC')
                 ->limit(30)

--- a/packages/processton/abacus/resources/views/balance-sheet-pdf.blade.php
+++ b/packages/processton/abacus/resources/views/balance-sheet-pdf.blade.php
@@ -203,7 +203,7 @@
             <div class="report-date">As at {{ $year->end_date->format('F d, Y') }}</div>
             <div class="report-date">For the Year Ended {{ $year->end_date->format('F d, Y') }}</div>
         @else
-            <div class="report-date">As at {{ now()->format('F d, Y') }}</div>
+            <div class="report-date">As at @hdate(now(), 'F d, Y')</div>
         @endif
     </div>
 

--- a/packages/processton/abacus/src/Filament/Pages/BalanceSheet.php
+++ b/packages/processton/abacus/src/Filament/Pages/BalanceSheet.php
@@ -2,6 +2,7 @@
 
 namespace Processton\Abacus\Filament\Pages;
 
+use App\Helpers\DateHelper;
 use Barryvdh\DomPDF\Facade\Pdf;
 use Filament\Forms;
 use Filament\Forms\Concerns\InteractsWithForms;
@@ -214,7 +215,7 @@ class BalanceSheet extends Page implements HasForms
             'totalAssets' => $totalAssets,
             'totalLiabilities' => $totalLiabilities,
             'totalEquity' => $totalEquity,
-            'generatedAt' => now()->format('Y-m-d H:i:s'),
+            'generatedAt' => DateHelper::pdfFormat(now(), 'Y-m-d H:i:s'),
         ];
 
         $pdf = \App::make('dompdf.wrapper');
@@ -264,7 +265,7 @@ class BalanceSheet extends Page implements HasForms
             'totalAssets' => $totalAssets,
             'totalLiabilities' => $totalLiabilities,
             'totalEquity' => $totalEquity,
-            'generatedAt' => now()->format('Y-m-d H:i:s'),
+            'generatedAt' => DateHelper::pdfFormat(now(), 'Y-m-d H:i:s'),
         ];
 
         // return view('abacus::balance-sheet-pdf', $data);

--- a/packages/processton/abacus/src/Filament/Pages/CashFlowStatement.php
+++ b/packages/processton/abacus/src/Filament/Pages/CashFlowStatement.php
@@ -2,6 +2,7 @@
 
 namespace Processton\Abacus\Filament\Pages;
 
+use App\Helpers\DateHelper;
 use Filament\Actions\Action;
 use Filament\Forms;
 use Filament\Forms\Concerns\InteractsWithForms;
@@ -145,7 +146,7 @@ class CashFlowStatement extends Page implements HasForms
             'financingTotal' => $this->financingTotal,
             'netChange' => $this->netChange,
             'selectedYear' => AbacusYear::find($this->yearId),
-            'generatedAt' => now()->format('Y-m-d H:i:s'),
+            'generatedAt' => DateHelper::pdfFormat(now(), 'Y-m-d H:i:s'),
         ];
 
         $pdf = \App::make('dompdf.wrapper');
@@ -182,7 +183,7 @@ class CashFlowStatement extends Page implements HasForms
             'financingTotal' => $this->financingTotal,
             'netChange' => $this->netChange,
             'selectedYear' => AbacusYear::find($this->yearId),
-            'generatedAt' => now()->format('Y-m-d H:i:s'),
+            'generatedAt' => DateHelper::pdfFormat(now(), 'Y-m-d H:i:s'),
         ];
 
         $pdf = \App::make('dompdf.wrapper');

--- a/packages/processton/abacus/src/Filament/Pages/GeneralLedger.php
+++ b/packages/processton/abacus/src/Filament/Pages/GeneralLedger.php
@@ -2,6 +2,7 @@
 
 namespace Processton\Abacus\Filament\Pages;
 
+use App\Helpers\DateHelper;
 use Filament\Actions\Action;
 use Filament\Forms;
 use Filament\Forms\Concerns\InteractsWithForms;
@@ -191,7 +192,7 @@ class GeneralLedger extends Page implements HasForms
             'endDate' => $this->endDate,
             'totalDebit' => $totalDebit,
             'totalCredit' => $totalCredit,
-            'generatedAt' => now()->format('Y-m-d H:i:s'),
+            'generatedAt' => DateHelper::pdfFormat(now(), 'Y-m-d H:i:s'),
         ];
 
         $pdf = \App::make('dompdf.wrapper');
@@ -259,7 +260,7 @@ class GeneralLedger extends Page implements HasForms
             'endDate' => $this->endDate,
             'totalDebit' => $totalDebit,
             'totalCredit' => $totalCredit,
-            'generatedAt' => now()->format('Y-m-d H:i:s'),
+            'generatedAt' => DateHelper::pdfFormat(now(), 'Y-m-d H:i:s'),
         ];
 
         $pdf = \App::make('dompdf.wrapper');

--- a/packages/processton/abacus/src/Filament/Pages/ProfitLossStatement.php
+++ b/packages/processton/abacus/src/Filament/Pages/ProfitLossStatement.php
@@ -2,6 +2,7 @@
 
 namespace Processton\Abacus\Filament\Pages;
 
+use App\Helpers\DateHelper;
 use Filament\Actions\Action;
 use Filament\Forms;
 use Filament\Forms\Concerns\InteractsWithForms;
@@ -169,7 +170,7 @@ class ProfitLossStatement extends Page implements HasForms
             'endDate' => $this->endDate,
             'totalIncome' => $this->totalIncome,
             'totalExpense' => $this->totalExpense,
-            'generatedAt' => now()->format('Y-m-d H:i:s'),
+            'generatedAt' => DateHelper::pdfFormat(now(), 'Y-m-d H:i:s'),
         ];
 
         $pdf = \App::make('dompdf.wrapper');
@@ -207,7 +208,7 @@ class ProfitLossStatement extends Page implements HasForms
             'endDate' => $this->endDate,
             'totalIncome' => $this->totalIncome,
             'totalExpense' => $this->totalExpense,
-            'generatedAt' => now()->format('Y-m-d H:i:s'),
+            'generatedAt' => DateHelper::pdfFormat(now(), 'Y-m-d H:i:s'),
         ];
 
         $pdf = \App::make('dompdf.wrapper');

--- a/packages/processton/abacus/src/Filament/Pages/TrialBalance.php
+++ b/packages/processton/abacus/src/Filament/Pages/TrialBalance.php
@@ -2,6 +2,7 @@
 
 namespace Processton\Abacus\Filament\Pages;
 
+use App\Helpers\DateHelper;
 use Filament\Actions\Action;
 use Filament\Forms;
 use Filament\Forms\Concerns\InteractsWithForms;
@@ -129,7 +130,7 @@ class TrialBalance extends Page implements HasForms
             'endDate' => $this->endDate,
             'totalDebit' => $this->rows->sum('debit'),
             'totalCredit' => $this->rows->sum('credit'),
-            'generatedAt' => now()->format('Y-m-d H:i:s'),
+            'generatedAt' => DateHelper::pdfFormat(now(), 'Y-m-d H:i:s'),
         ];
 
         $pdf = \App::make('dompdf.wrapper');
@@ -170,7 +171,7 @@ class TrialBalance extends Page implements HasForms
             'endDate' => $this->endDate,
             'totalDebit' => $this->rows->sum('debit'),
             'totalCredit' => $this->rows->sum('credit'),
-            'generatedAt' => now()->format('Y-m-d H:i:s'),
+            'generatedAt' => DateHelper::pdfFormat(now(), 'Y-m-d H:i:s'),
         ];
 
         $pdf = \App::make('dompdf.wrapper');

--- a/tests/Feature/PdfTimezoneTest.php
+++ b/tests/Feature/PdfTimezoneTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use App\Helpers\DateHelper;
+use App\Models\HospitalSetting;
+use Carbon\Carbon;
+
+beforeEach(function () {
+    DateHelper::flushTimezoneCache();
+});
+
+afterEach(function () {
+    DateHelper::flushTimezoneCache();
+    Carbon::setTestNow();
+});
+
+test('pdf generated_at timestamp renders in the hospital timezone, not UTC', function () {
+    HospitalSetting::set('hospital_timezone', 'Asia/Karachi');
+    DateHelper::flushTimezoneCache();
+
+    // 22:30 UTC on the 22nd is already 03:30 on the 23rd in Asia/Karachi (+05:00).
+    Carbon::setTestNow(Carbon::parse('2026-05-22 22:30:00', 'UTC'));
+
+    // This is the exact expression the Abacus accounting PDFs use for "Generated on".
+    $rendered = DateHelper::pdfFormat(now(), 'Y-m-d H:i:s');
+
+    expect($rendered)->toBe('2026-05-23 03:30:00')
+        ->and($rendered)->not->toBe(now()->format('Y-m-d H:i:s'));
+});
+
+test('pdf dates follow the configured hospital timezone setting', function () {
+    Carbon::setTestNow(Carbon::parse('2026-05-22 22:30:00', 'UTC'));
+
+    HospitalSetting::set('hospital_timezone', 'UTC');
+    DateHelper::flushTimezoneCache();
+    expect(DateHelper::pdfFormat(now(), 'Y-m-d H:i'))->toBe('2026-05-22 22:30');
+
+    HospitalSetting::set('hospital_timezone', 'Asia/Karachi');
+    DateHelper::flushTimezoneCache();
+    expect(DateHelper::pdfFormat(now(), 'Y-m-d H:i'))->toBe('2026-05-23 03:30');
+});
+
+test('pdf timezone falls back to Asia/Karachi when the setting is absent', function () {
+    expect(DateHelper::timezone())->toBe('Asia/Karachi');
+});

--- a/tests/Feature/ReportFilterTimezoneTest.php
+++ b/tests/Feature/ReportFilterTimezoneTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use App\Helpers\DateHelper;
+use App\Models\HospitalSetting;
+use Carbon\Carbon;
+
+beforeEach(function () {
+    HospitalSetting::set('hospital_timezone', 'Asia/Karachi');
+    DateHelper::flushTimezoneCache();
+});
+
+afterEach(function () {
+    DateHelper::flushTimezoneCache();
+    Carbon::setTestNow();
+});
+
+test('dayStartUtc converts a hospital-local day to the correct UTC instant', function () {
+    // Start of 23 May in Asia/Karachi (+05:00) is 22 May 19:00 UTC.
+    expect(DateHelper::dayStartUtc('2026-05-23')->toDateTimeString())->toBe('2026-05-22 19:00:00');
+});
+
+test('dayEndUtc converts a hospital-local day to the correct UTC instant', function () {
+    // End of 23 May in Asia/Karachi (+05:00) is 23 May 18:59:59 UTC.
+    expect(DateHelper::dayEndUtc('2026-05-23')->toDateTimeString())->toBe('2026-05-23 18:59:59');
+});
+
+test('a record just after local midnight is inside the selected hospital day', function () {
+    // 22 May 21:00 UTC == 23 May 02:00 in Asia/Karachi.
+    $createdAt = Carbon::parse('2026-05-22 21:00:00', 'UTC');
+
+    expect($createdAt->between(
+        DateHelper::dayStartUtc('2026-05-23'),
+        DateHelper::dayEndUtc('2026-05-23'),
+    ))->toBeTrue();
+});
+
+test('a record just before next local midnight is excluded from the selected hospital day', function () {
+    // 23 May 20:00 UTC == 24 May 01:00 in Asia/Karachi, so it belongs to the 24th.
+    $createdAt = Carbon::parse('2026-05-23 20:00:00', 'UTC');
+
+    expect($createdAt->between(
+        DateHelper::dayStartUtc('2026-05-23'),
+        DateHelper::dayEndUtc('2026-05-23'),
+    ))->toBeFalse();
+});
+
+test('the boundary helpers honour a changed hospital timezone', function () {
+    HospitalSetting::set('hospital_timezone', 'UTC');
+    DateHelper::flushTimezoneCache();
+
+    expect(DateHelper::dayStartUtc('2026-05-23')->toDateTimeString())->toBe('2026-05-23 00:00:00')
+        ->and(DateHelper::dayEndUtc('2026-05-23')->toDateTimeString())->toBe('2026-05-23 23:59:59');
+});
+
+test('todayRangeUtc spans the hospital-local day in UTC', function () {
+    // 01:00 on 23 May in Asia/Karachi is still 22 May 20:00 UTC.
+    Carbon::setTestNow(Carbon::parse('2026-05-22 20:00:00', 'UTC'));
+
+    [$start, $end] = DateHelper::todayRangeUtc();
+
+    expect($start->toDateTimeString())->toBe('2026-05-22 19:00:00')
+        ->and($end->toDateTimeString())->toBe('2026-05-23 18:59:59');
+});


### PR DESCRIPTION
## Summary

This PR fixes timezone handling in date range filters throughout the application. Previously, date filters were using `whereDate()` which operates on the date portion only, ignoring timezone differences. This caused reports to include or exclude records based on UTC dates rather than hospital-local dates.

The fix introduces a new `DateHelper` utility with methods to convert hospital-timezone dates to UTC datetime boundaries, ensuring that all datetime-column filters correctly align with stored data regardless of the server's timezone.

## Key Changes

- **DateHelper enhancements** (`app/Helpers/DateHelper.php`):
  - Added `dayStartUtc()` - converts a hospital-local day start to UTC instant (for `>=` filters)
  - Added `dayEndUtc()` - converts a hospital-local day end to UTC instant (for `<=` filters)
  - Added `todayRangeUtc()` - returns UTC range covering "today" in hospital timezone
  - Added private `inHospitalTimezone()` helper to interpret dates in hospital timezone

- **Report controllers** (`GenericReportPdfController`, `IncomeCashFlowReportController`, `PanelPaymentReportController`, `BankPaymentReportController`):
  - Replaced `whereDate()` calls with `where()` using `DateHelper::dayStartUtc()` and `DateHelper::dayEndUtc()`
  - Extracted date range resolution into `resolveDateRange()` method in `GenericReportPdfController`
  - Updated all report methods (income, expense, receivables, services, serviceOrders, servicePerformance) to use the new helpers
  - Changed date defaults to use `now(DateHelper::timezone())` instead of `now()`

- **Dashboard and stats** (`AdminStatsOverview`, `HasDashboardDateFilters`):
  - Updated date filter initialization to use hospital timezone
  - Replaced `whereDate()` with `where()` using UTC boundary helpers
  - Fixed date range calculations to respect hospital timezone

- **Exports** (`IncomeReportExport`, `ExpenseReportExport`, `ReceivablesReportExport`, `ServicesReportExport`, `ServicePerformanceReportExport`, `ServiceProviderReportExport`):
  - Updated all date filters to use `DateHelper::dayStartUtc()` and `DateHelper::dayEndUtc()`

- **API controllers** (`ExpenseVoucherController`, `ServiceOrderController`, `TransactionController`, `OpdController`):
  - Updated date filters to use the new UTC boundary helpers

- **Web and other controllers** (`WebController`, `DentistController`, `EmergencyDoctorController`, `LabController`, `OpdDoctorController`, `UltrasoundController`, `XrayController`):
  - Updated date filters and defaults to use hospital timezone

- **Filament pages** (BalanceSheet, CashFlowStatement, GeneralLedger, ProfitLossStatement, TrialBalance):
  - Added DateHelper imports for consistent timezone handling

- **Tests** (new):
  - Added `ReportFilterTimezoneTest.php` - comprehensive tests for `dayStartUtc()`, `dayEndUtc()`, and `todayRangeUtc()`
  - Added `PdfTimezoneTest.php` - tests for PDF date formatting in hospital timezone

## Implementation Details

The core issue was that `whereDate('created_at', '>=', $date)` extracts only the date portion from both sides, losing timezone information. The fix uses:

```php
// Before (incorrect for timezones)
->whereDate('created_at', '>=', $from)
->whereDate('created_at', '<=', $until)

// After (correct)
->where('created_at', '>=', DateHelper::dayStartUtc($from))
->where('created_at', '<=', DateHelper::dayEndUtc($until))
```

This ensures that a user selecting "23 May" in Asia/Karachi timezone correctly filters records created between 2026-05-22 19:00:00 UTC and 2026-05-23 18:59:59 UTC.

https://claude.ai/code/session_01CEWMzZcM8KsxDmU9J8JxLQ