### PR TITLE
feat: display so_short alongside SO number in UI and prints

### DIFF
--- a/resources/js/elements/patient/transactions-history-card.tsx
+++ b/resources/js/elements/patient/transactions-history-card.tsx
@@ -90,7 +90,7 @@ const PatientTreatmentsHistory: React.FC<{ treatments: ServiceOrder[] }> = ({
                             key={treatment.id}
                             className="flex flex-col rounded-md border p-3"
                         >
-                            <div className="">{treatment.so_number}</div>
+                            <div className="">{treatment.so_number}{treatment.so_short ? ` (${treatment.so_short})` : ''}</div>
                             <div className="flex flex-col items-center justify-between md:flex-row">
                                 <div className="w-full">
                                     <p>

--- a/resources/js/elements/patient/transactions-history-card.tsx
+++ b/resources/js/elements/patient/transactions-history-card.tsx
@@ -90,7 +90,12 @@ const PatientTreatmentsHistory: React.FC<{ treatments: ServiceOrder[] }> = ({
                             key={treatment.id}
                             className="flex flex-col rounded-md border p-3"
                         >
-                            <div className="">{treatment.so_number}{treatment.so_short ? ` (${treatment.so_short})` : ''}</div>
+                            <div className="">
+                                {treatment.so_number}
+                                {treatment.so_short
+                                    ? ` (${treatment.so_short})`
+                                    : ''}
+                            </div>
                             <div className="flex flex-col items-center justify-between md:flex-row">
                                 <div className="w-full">
                                     <p>

--- a/resources/js/elements/serviceorder/filter-and-select-serviceorder.tsx
+++ b/resources/js/elements/serviceorder/filter-and-select-serviceorder.tsx
@@ -25,6 +25,7 @@ import { LoaderCircle, Search } from 'lucide-react';
 export interface ServiceOrderSearchItem {
     id: number;
     so_number: string;
+    so_short?: string;
     type?: string;
     created_at?: string;
     patient?: {
@@ -239,7 +240,7 @@ export default function FilterAndSelectServiceOrder({
                             onClick={() => selectServiceOrder(item)}
                             className="w-full border-b px-3 py-2 text-left last:border-b-0 hover:bg-muted/40"
                         >
-                            <div className="font-medium">{item.so_number}</div>
+                            <div className="font-medium">{item.so_number}{item.so_short ? ` (${item.so_short})` : ''}</div>
                             <div className="text-xs text-muted-foreground">
                                 {item.patient?.name ?? 'N/A'} |{' '}
                                 {item.service?.name ?? 'N/A'}
@@ -252,7 +253,7 @@ export default function FilterAndSelectServiceOrder({
             {selected ? (
                 <div className="flex items-center justify-between rounded-md border bg-muted/20 p-2 text-sm">
                     <div>
-                        <div className="font-medium">{selected.so_number}</div>
+                        <div className="font-medium">{selected.so_number}{selected.so_short ? ` (${selected.so_short})` : ''}</div>
                         <div className="text-xs text-muted-foreground">
                             {selected.patient?.name ?? 'No patient linked'}
                         </div>
@@ -377,7 +378,7 @@ export default function FilterAndSelectServiceOrder({
                                     className="w-full border-b px-3 py-2 text-left last:border-b-0 hover:bg-muted/40"
                                 >
                                     <div className="font-medium">
-                                        {item.so_number}
+                                        {item.so_number}{item.so_short ? ` (${item.so_short})` : ''}
                                     </div>
                                     <div className="text-xs text-muted-foreground">
                                         {item.patient?.name ?? 'N/A'} |{' '}

--- a/resources/js/elements/serviceorder/filter-and-select-serviceorder.tsx
+++ b/resources/js/elements/serviceorder/filter-and-select-serviceorder.tsx
@@ -240,7 +240,10 @@ export default function FilterAndSelectServiceOrder({
                             onClick={() => selectServiceOrder(item)}
                             className="w-full border-b px-3 py-2 text-left last:border-b-0 hover:bg-muted/40"
                         >
-                            <div className="font-medium">{item.so_number}{item.so_short ? ` (${item.so_short})` : ''}</div>
+                            <div className="font-medium">
+                                {item.so_number}
+                                {item.so_short ? ` (${item.so_short})` : ''}
+                            </div>
                             <div className="text-xs text-muted-foreground">
                                 {item.patient?.name ?? 'N/A'} |{' '}
                                 {item.service?.name ?? 'N/A'}
@@ -253,7 +256,10 @@ export default function FilterAndSelectServiceOrder({
             {selected ? (
                 <div className="flex items-center justify-between rounded-md border bg-muted/20 p-2 text-sm">
                     <div>
-                        <div className="font-medium">{selected.so_number}{selected.so_short ? ` (${selected.so_short})` : ''}</div>
+                        <div className="font-medium">
+                            {selected.so_number}
+                            {selected.so_short ? ` (${selected.so_short})` : ''}
+                        </div>
                         <div className="text-xs text-muted-foreground">
                             {selected.patient?.name ?? 'No patient linked'}
                         </div>
@@ -378,7 +384,10 @@ export default function FilterAndSelectServiceOrder({
                                     className="w-full border-b px-3 py-2 text-left last:border-b-0 hover:bg-muted/40"
                                 >
                                     <div className="font-medium">
-                                        {item.so_number}{item.so_short ? ` (${item.so_short})` : ''}
+                                        {item.so_number}
+                                        {item.so_short
+                                            ? ` (${item.so_short})`
+                                            : ''}
                                     </div>
                                     <div className="text-xs text-muted-foreground">
                                         {item.patient?.name ?? 'N/A'} |{' '}

--- a/resources/js/elements/serviceorder/service-order-card.tsx
+++ b/resources/js/elements/serviceorder/service-order-card.tsx
@@ -26,6 +26,7 @@ const ServiceOrderCard: React.FC<ServiceOrderCardProps> = ({
             <div className="min-w-0">
                 <p className="font-mono text-xs text-muted-foreground">
                     {serviceOrder.so_number}
+                    {serviceOrder.so_short ? ` (${serviceOrder.so_short})` : ''}
                 </p>
                 <p className="mt-0.5 text-sm font-semibold">
                     {serviceOrder.type}

--- a/resources/js/elements/serviceorder/service-order-detailed-card.tsx
+++ b/resources/js/elements/serviceorder/service-order-detailed-card.tsx
@@ -19,7 +19,9 @@ const ServiceOrderDetailedCard: React.FC<ServiceOrderDetailedCardProps> = ({
                 <div>
                     <CardTitle className="font-mono text-base">
                         {serviceOrder.so_number}
-                        {serviceOrder.so_short ? ` (${serviceOrder.so_short})` : ''}
+                        {serviceOrder.so_short
+                            ? ` (${serviceOrder.so_short})`
+                            : ''}
                     </CardTitle>
                     <p className="mt-0.5 text-xs text-muted-foreground">
                         {serviceOrder.created_at}

--- a/resources/js/elements/serviceorder/service-order-detailed-card.tsx
+++ b/resources/js/elements/serviceorder/service-order-detailed-card.tsx
@@ -19,6 +19,7 @@ const ServiceOrderDetailedCard: React.FC<ServiceOrderDetailedCardProps> = ({
                 <div>
                     <CardTitle className="font-mono text-base">
                         {serviceOrder.so_number}
+                        {serviceOrder.so_short ? ` (${serviceOrder.so_short})` : ''}
                     </CardTitle>
                     <p className="mt-0.5 text-xs text-muted-foreground">
                         {serviceOrder.created_at}

--- a/resources/js/elements/serviceorder/service-order-list-item.tsx
+++ b/resources/js/elements/serviceorder/service-order-list-item.tsx
@@ -31,6 +31,7 @@ const ServiceOrderListItem: React.FC<ServiceOrderListItemProps> = ({
         <div className="min-w-0">
             <p className="font-mono text-xs text-muted-foreground">
                 {serviceOrder.so_number}
+                {serviceOrder.so_short ? ` (${serviceOrder.so_short})` : ''}
             </p>
             <p className="text-sm font-medium">{serviceOrder.type}</p>
         </div>

--- a/resources/js/elements/serviceorder/service-order-table-element.tsx
+++ b/resources/js/elements/serviceorder/service-order-table-element.tsx
@@ -15,6 +15,7 @@ const ServiceOrderTableElement: React.FC<ServiceOrderTableElementProps> = ({
         <div className="min-w-0">
             <p className="font-mono text-xs text-muted-foreground">
                 {serviceOrder.so_number}
+                {serviceOrder.so_short ? ` (${serviceOrder.so_short})` : ''}
             </p>
             <p className="truncate text-sm font-medium">{serviceOrder.type}</p>
         </div>

--- a/resources/js/elements/serviceorder/service-orders-listing-table.tsx
+++ b/resources/js/elements/serviceorder/service-orders-listing-table.tsx
@@ -44,6 +44,7 @@ const ServiceOrdersListingTable: React.FC<ServiceOrdersListingTableProps> = ({
                         >
                             <td className="px-4 py-2 font-mono text-xs">
                                 {so.so_number}
+                                {so.so_short ? ` (${so.so_short})` : ''}
                             </td>
                             <td className="px-4 py-2">{so.type}</td>
                             <td className="px-4 py-2">

--- a/resources/js/pages/hospital/opd-queue.tsx
+++ b/resources/js/pages/hospital/opd-queue.tsx
@@ -124,6 +124,7 @@ function TokenCard({ item, variant = 'open', minify }) {
                     {item.so_number && minify == false ? (
                         <div className="text-xs text-slate-500">
                             MRI #: {item.so_number}
+                            {item.so_short ? ` (${item.so_short})` : ''}
                         </div>
                     ) : null}
                     <div className="mt-4 flex items-center justify-between text-sm">

--- a/resources/views/pdfs/reports/generic-service-order-detail.blade.php
+++ b/resources/views/pdfs/reports/generic-service-order-detail.blade.php
@@ -12,7 +12,7 @@
 <table>
     <tr>
         <td style="width: 25%;"><span class="info-label">SO Number</span></td>
-        <td class="mono text-bold">{{ $order->so_number }}@if($order->token_short) <span class="badge badge-blue">Token #{{ $order->token_short }}</span>@endif</td>
+        <td class="mono text-bold">{{ $order->so_number }}{{ $order->so_short ? ' ('.$order->so_short.')' : '' }}@if($order->token_short) <span class="badge badge-blue">Token #{{ $order->token_short }}</span>@endif</td>
         <td style="width: 25%;"><span class="info-label">Status</span></td>
         <td>
             <span class="badge {{ $order->status === 'closed' ? 'badge-green' : 'badge-orange' }}">
@@ -252,6 +252,6 @@
 </table>
 
 @include('pdfs.reports.partials.generic-footer', [
-    'report_title' => 'Service Order Detail — ' . $order->so_number,
+    'report_title' => 'Service Order Detail — ' . $order->so_number . ($order->so_short ? ' ('.$order->so_short.')' : ''),
     'generated_at' => $generated_at,
 ])

--- a/resources/views/pdfs/reports/generic-service-performance.blade.php
+++ b/resources/views/pdfs/reports/generic-service-performance.blade.php
@@ -66,7 +66,7 @@
             <td>{{ $i + 1 }}</td>
             <td>@hdate($order->created_at, 'd M Y')</td>
             <td>
-                <strong class="mono" style="font-size: 9px;">{{ $order->so_number }}</strong>@if($order->token_short) <span class="badge badge-blue" style="font-size: 8px;">Token #{{ $order->token_short }}</span>@endif<br>
+                <strong class="mono" style="font-size: 9px;">{{ $order->so_number }}{{ $order->so_short ? ' ('.$order->so_short.')' : '' }}</strong>@if($order->token_short) <span class="badge badge-blue" style="font-size: 8px;">Token #{{ $order->token_short }}</span>@endif<br>
                 <span class="text-muted" style="font-size: 9px;">
                     {{ collect([$order->patient?->name, $order->service?->name, $order->doctor?->name])->filter()->implode(' · ') }}
                 </span>

--- a/resources/views/pdfs/reports/generic-service-provider.blade.php
+++ b/resources/views/pdfs/reports/generic-service-provider.blade.php
@@ -74,7 +74,7 @@
             <td>{{ $i + 1 }}</td>
             <td>@hdate($order->created_at, 'd M Y')</td>
             <td>
-                <strong class="mono" style="font-size: 9px;">{{ $order->so_number }}</strong>@if($order->token_short) <span class="badge badge-blue" style="font-size: 8px;">Token #{{ $order->token_short }}</span>@endif<br>
+                <strong class="mono" style="font-size: 9px;">{{ $order->so_number }}{{ $order->so_short ? ' ('.$order->so_short.')' : '' }}</strong>@if($order->token_short) <span class="badge badge-blue" style="font-size: 8px;">Token #{{ $order->token_short }}</span>@endif<br>
                 <span class="text-muted" style="font-size: 9px;">
                     {{ collect([$order->patient?->name, $order->service?->name])->filter()->implode(' · ') }}
                 </span>
@@ -127,7 +127,7 @@
             <tr>
                 <td>@hdate($voucher->created_at, 'd M Y')</td>
                 <td class="mono">{{ $voucher->vc_number }}</td>
-                <td class="mono" style="font-size: 9px;">{{ $order->so_number }}</td>
+                <td class="mono" style="font-size: 9px;">{{ $order->so_number }}{{ $order->so_short ? ' ('.$order->so_short.')' : '' }}</td>
                 <td>{{ $voucher->expCategory?->name ?? '-' }}</td>
                 <td class="amount" style="color: #991b1b;">{{ number_format($voucher->amount, 2) }}</td>
             </tr>

--- a/resources/views/pdfs/serviceorder.blade.php
+++ b/resources/views/pdfs/serviceorder.blade.php
@@ -219,7 +219,7 @@
 
         <div class="heading-wrap">
             <div class="badge d-block text-center">EMERGENCY DEPARTMENT</div>
-            <div class="subhead">CLINICAL PERFORMA SO: <span class="u">{{ $serviceOrder->so_number ?? '' }}</span> Page 1/2</div>
+            <div class="subhead">CLINICAL PERFORMA SO: <span class="u">{{ $serviceOrder->so_number ?? '' }}{{ $serviceOrder->so_short ? ' ('.$serviceOrder->so_short.')' : '' }}</span> Page 1/2</div>
         </div>
 
         <table style="width:100%; margin-top:12px; border-collapse:collapse;">
@@ -228,7 +228,7 @@
                     <table class="kv-table">
                         <tr>
                             <td class="kv-label" style="width:30%;">MR # :</td>
-                            <td class="kv-line w-mid" style="width:70%;">{{ $serviceOrder->so_number ?? '' }}</td>
+                            <td class="kv-line w-mid" style="width:70%;">{{ $serviceOrder->so_number ?? '' }}{{ $serviceOrder->so_short ? ' ('.$serviceOrder->so_short.')' : '' }}</td>
                         </tr>
                         <tr>
                             <td class="kv-label">Date:</td>

--- a/resources/views/pdfs/transaction/transaction-thermal.blade.php
+++ b/resources/views/pdfs/transaction/transaction-thermal.blade.php
@@ -267,7 +267,7 @@
                 </div>
                 @if($item->serviceOrder)
                 <div class="order-line">
-                    MRI: {{ $item->serviceOrder->so_number }} {{ $item?->doctor?->name}}
+                    MRI: {{ $item->serviceOrder->so_short }} {{ $item?->doctor?->name}}
                 </div>
                 @endif
             @endforeach


### PR DESCRIPTION
## Summary\n\n- Show `so_short` in brackets next to `so_number` across all frontend React components (cards, tables, list items, queue, search dialogs) and Blade print templates (serviceorder performa, reports)\n- In transaction thermal print, use only `so_short` instead of full `so_number` since the patient's `ps_number` is already displayed — avoids redundant repetition on the receipt\n- Added `so_short` to `ServiceOrderSearchItem` TypeScript interface for the filter/search component\n\n## Test plan\n\n- [x] Frontend builds successfully (`npx vite build`)\n- [x] 36 ServiceOrder tests pass\n- [x] 78 PDF/Transaction/Print tests pass\n- [ ] Verify SO number displays as `PS/2026/01/0042/OPD/00000001 (OPD/00000001)` in frontend views\n- [ ] Verify transaction thermal receipt shows only `so_short` (e.g. `OPD/00000001`) in the MRI line\n\nhttps://claude.ai/code/session_01SRSLT6XobrLVeXWSXMhHAg

---
_Generated by [Claude Code](https://claude.ai/code/session_01SRSLT6XobrLVeXWSXMhHAg)_