### PR TITLE
revert: remove print restriction on non-closed counters

### DIFF
--- a/app/Http/Controllers/Prints/ClosingStatementPdfPrintController.php
+++ b/app/Http/Controllers/Prints/ClosingStatementPdfPrintController.php
@@ -64,15 +64,6 @@ class ClosingStatementPdfPrintController extends Controller
             abort(404, "Closing statement {$ctNumber} not found");
         }
 
-        // Only finalised counters may be printed. While a counter is still OPEN its
-        // figures are not final, so printing the statement or any report is blocked
-        // for regular staff. Administrators may still print an in-progress counter.
-        $isFinalised = in_array(strtoupper((string) $closing->status), ['CLOSED', 'REPORTED'], true);
-
-        if (! $isFinalised && ! $request->user()?->isAdmin()) {
-            abort(403, "Counter {$ctNumber} must be closed before it can be printed.");
-        }
-
         // If a specific report type is requested, generate that report
         if ($report && in_array($report, $allowedReports)) {
             $data = $this->prepareClosingData($closing);

--- a/resources/js/pages/counter/view.tsx
+++ b/resources/js/pages/counter/view.tsx
@@ -174,20 +174,6 @@ const tabConfig: { key: CounterTab; label: string; color: string }[] = [
 const CounterViewTabs = ({ openCounter }: { openCounter: any }) => {
     const [activeTab, setActiveTab] = useState<CounterTab>('general');
 
-    // A counter statement can only be printed once the shift is closed (or
-    // reported). While it is still OPEN the figures are not final, so the print
-    // and report tabs are hidden for regular staff. Administrators may still
-    // print an in-progress counter.
-    const { auth } = usePage().props as unknown as { auth: any };
-    const isAdmin = (auth?.user?.profiles?.admin?.length ?? 0) > 0;
-    const counterStatus = String(openCounter.status ?? '').toUpperCase();
-    const canPrint =
-        counterStatus === 'CLOSED' || counterStatus === 'REPORTED' || isAdmin;
-
-    const visibleTabs = canPrint
-        ? tabConfig
-        : tabConfig.filter((tab) => tab.key === 'general');
-
     const closingUrl = printClosingStatement({
         year: openCounter.year,
         month: openCounter.month,
@@ -197,7 +183,7 @@ const CounterViewTabs = ({ openCounter }: { openCounter: any }) => {
     return (
         <>
             <div className="flex flex-row gap-2 divide-y-0 divide-gray-300 overflow-x-auto border-b">
-                {visibleTabs.map((tab) => (
+                {tabConfig.map((tab) => (
                     <button
                         key={tab.key}
                         onClick={() => setActiveTab(tab.key)}

--- a/tests/Feature/Web/ClosingStatementPrintRestrictionTest.php
+++ b/tests/Feature/Web/ClosingStatementPrintRestrictionTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use App\Models\Administrator;
 use App\Models\Closing;
 use App\Models\User;
 
@@ -16,18 +15,8 @@ function printUrlFor(Closing $closing): string
     ]);
 }
 
-test('an open counter cannot be printed by regular staff', function () {
+test('any counter can be printed regardless of status', function () {
     $user = User::factory()->create();
-    $closing = Closing::factory()->create(['status' => 'OPEN']);
-
-    actingAs($user);
-
-    get(printUrlFor($closing))->assertForbidden();
-});
-
-test('an admin can print an open counter', function () {
-    $user = User::factory()->create();
-    Administrator::create(['user_id' => $user->id, 'authority' => 'administrator']);
     $closing = Closing::factory()->create(['status' => 'OPEN']);
 
     actingAs($user);


### PR DESCRIPTION
## Summary

- Removes the status-based 403 guard from `ClosingStatementPdfPrintController` that blocked printing for non-closed counters
- Removes the frontend tab visibility condition in `counter/view.tsx` that hid print/report tabs on open counters
- Updates tests to reflect that any counter can now be printed regardless of status

## Test plan

- [ ] Open a counter (status OPEN) and verify all tabs (print, reports) are visible
- [ ] Print a closing statement for an open counter — should succeed without 403
- [ ] Print a closing statement for a closed counter — should still work as before

https://claude.ai/code/session_01LsWnDT3jMBmQPdtGyfqyUx

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsWnDT3jMBmQPdtGyfqyUx)_