### PR TITLE
Add LCD department roles, open My Payments, group CT print by service/provider

### DIFF
--- a/app/Filament/Admin/Resources/Users/Schemas/UserForm.php
+++ b/app/Filament/Admin/Resources/Users/Schemas/UserForm.php
@@ -280,6 +280,132 @@ class UserForm
                     ->collapsible()
                     ->collapsed()
                     ->columnSpanFull(),
+
+                Repeater::make('lcdOpdProfiles')
+                    ->label('LCD Display — OPD Profiles')
+                    ->relationship()
+                    ->schema([
+                        Select::make('authority')
+                            ->options([
+                                'operator' => 'Operator',
+                                'supervisor' => 'Supervisor',
+                            ])
+                            ->default('operator')
+                            ->required(),
+                    ])
+                    ->defaultItems(0)
+                    ->addActionLabel('Add LCD OPD Profile')
+                    ->collapsible()
+                    ->collapsed()
+                    ->columnSpanFull(),
+
+                Repeater::make('lcdIndProfiles')
+                    ->label('LCD Display — Indoor Profiles')
+                    ->relationship()
+                    ->schema([
+                        Select::make('authority')
+                            ->options([
+                                'operator' => 'Operator',
+                                'supervisor' => 'Supervisor',
+                            ])
+                            ->default('operator')
+                            ->required(),
+                    ])
+                    ->defaultItems(0)
+                    ->addActionLabel('Add LCD Indoor Profile')
+                    ->collapsible()
+                    ->collapsed()
+                    ->columnSpanFull(),
+
+                Repeater::make('lcdEmergencyProfiles')
+                    ->label('LCD Display — Emergency Profiles')
+                    ->relationship()
+                    ->schema([
+                        Select::make('authority')
+                            ->options([
+                                'operator' => 'Operator',
+                                'supervisor' => 'Supervisor',
+                            ])
+                            ->default('operator')
+                            ->required(),
+                    ])
+                    ->defaultItems(0)
+                    ->addActionLabel('Add LCD Emergency Profile')
+                    ->collapsible()
+                    ->collapsed()
+                    ->columnSpanFull(),
+
+                Repeater::make('lcdDentalProfiles')
+                    ->label('LCD Display — Dental Profiles')
+                    ->relationship()
+                    ->schema([
+                        Select::make('authority')
+                            ->options([
+                                'operator' => 'Operator',
+                                'supervisor' => 'Supervisor',
+                            ])
+                            ->default('operator')
+                            ->required(),
+                    ])
+                    ->defaultItems(0)
+                    ->addActionLabel('Add LCD Dental Profile')
+                    ->collapsible()
+                    ->collapsed()
+                    ->columnSpanFull(),
+
+                Repeater::make('lcdLaboratoryProfiles')
+                    ->label('LCD Display — Laboratory Profiles')
+                    ->relationship()
+                    ->schema([
+                        Select::make('authority')
+                            ->options([
+                                'operator' => 'Operator',
+                                'supervisor' => 'Supervisor',
+                            ])
+                            ->default('operator')
+                            ->required(),
+                    ])
+                    ->defaultItems(0)
+                    ->addActionLabel('Add LCD Laboratory Profile')
+                    ->collapsible()
+                    ->collapsed()
+                    ->columnSpanFull(),
+
+                Repeater::make('lcdUltrasoundProfiles')
+                    ->label('LCD Display — Ultrasound Profiles')
+                    ->relationship()
+                    ->schema([
+                        Select::make('authority')
+                            ->options([
+                                'operator' => 'Operator',
+                                'supervisor' => 'Supervisor',
+                            ])
+                            ->default('operator')
+                            ->required(),
+                    ])
+                    ->defaultItems(0)
+                    ->addActionLabel('Add LCD Ultrasound Profile')
+                    ->collapsible()
+                    ->collapsed()
+                    ->columnSpanFull(),
+
+                Repeater::make('lcdXrayProfiles')
+                    ->label('LCD Display — X-Ray Profiles')
+                    ->relationship()
+                    ->schema([
+                        Select::make('authority')
+                            ->options([
+                                'operator' => 'Operator',
+                                'supervisor' => 'Supervisor',
+                            ])
+                            ->default('operator')
+                            ->required(),
+                    ])
+                    ->defaultItems(0)
+                    ->addActionLabel('Add LCD X-Ray Profile')
+                    ->collapsible()
+                    ->collapsed()
+                    ->columnSpanFull(),
             ]);
     }
 }

--- a/app/Http/Controllers/Prints/ClosingStatementPdfPrintController.php
+++ b/app/Http/Controllers/Prints/ClosingStatementPdfPrintController.php
@@ -36,17 +36,17 @@ class ClosingStatementPdfPrintController extends Controller
             'transactions.elements.service',
             'transactions.elements.doctor',
             'transactions.elements.expenseCategory',
+            // Needed on every print, not just ?report=income/receivables: the
+            // default statement now groups by service/provider and shows
+            // receivables created/collected too.
+            'transactions.elements.serviceRecestation',
+            'transactions.receaveable.patient',
+            'transactions.receaveable.panel',
+            'transactions.settledReceaveable.patient',
         ];
-
-        if ($report === 'receivables' || $report === 'income') {
-            $eagerLoads[] = 'transactions.receaveable.patient';
-            $eagerLoads[] = 'transactions.receaveable.panel';
-        }
 
         if ($report === 'services') {
             $eagerLoads[] = 'transactions.elements.serviceOrder';
-            $eagerLoads[] = 'transactions.elements.serviceRecestation';
-            $eagerLoads[] = 'transactions.elements.expenseCategory';
             $eagerLoads[] = 'transactions.elements.expVoucher.payedTo';
         }
 
@@ -180,6 +180,46 @@ class ClosingStatementPdfPrintController extends Controller
         // Calculate totals
         $netAmount = $totalIncome - $totalExpense;
 
+        // Receivables created during this closing (the creation direction —
+        // Transaction::receaveable() — vs. collected, which may settle a
+        // receivable created in an earlier closing).
+        $receivablesCreated = [];
+        $receivablesCreatedTotal = 0;
+        foreach ($closing->transactions as $transaction) {
+            $receaveable = $transaction->receaveable;
+            if (! $receaveable) {
+                continue;
+            }
+            $originalAmount = $receaveable->orignal_amount ?? $receaveable->amount;
+            $receivablesCreated[] = [
+                'transaction_number' => $transaction->tr_number,
+                'created_at' => $transaction->created_at,
+                'patient_name' => $receaveable->patient?->name ?? 'N/A',
+                'panel_name' => $receaveable->panel?->name ?? 'N/A',
+                'amount' => $originalAmount,
+                'status' => $receaveable->status ?? 'PENDING',
+            ];
+            $receivablesCreatedTotal += $originalAmount;
+        }
+
+        // Receivables collected during this closing (settlement direction —
+        // Transaction::settledReceaveable() / Transaction.receaveable_id).
+        $receivablesCollected = [];
+        $receivablesCollectedTotal = 0;
+        foreach ($closing->transactions as $transaction) {
+            if (! $transaction->receaveable_id) {
+                continue;
+            }
+            $receivablesCollected[] = [
+                'transaction_number' => $transaction->tr_number,
+                'created_at' => $transaction->created_at,
+                'patient_name' => $transaction->settledReceaveable?->patient?->name ?? 'N/A',
+                'method' => $transaction->type,
+                'amount' => $transaction->amount,
+            ];
+            $receivablesCollectedTotal += $transaction->amount;
+        }
+
         return [
             'closing' => [
                 'ct_number' => $closing->ct_number,
@@ -217,14 +257,79 @@ class ClosingStatementPdfPrintController extends Controller
                 'transactions_count' => count($closing->transactions),
                 'edited_count' => $editedCount,
                 'receaveables_count' => $receaveableCount,
+                'receivables_created_total' => $receivablesCreatedTotal,
+                'receivables_collected_total' => $receivablesCollectedTotal,
             ],
             'summary' => [
                 'income_count' => count($incomeTransactions),
                 'expense_count' => count($expenseTransactions),
                 'total_transactions' => count($closing->transactions),
             ],
+            'service_groups' => $this->buildServiceProviderGroups($closing),
+            'receivables' => [
+                'created' => $receivablesCreated,
+                'collected' => $receivablesCollected,
+            ],
             'generated_at' => Carbon::now(),
         ];
+    }
+
+    /**
+     * Group this closing's income transaction elements by Service →
+     * Service Provider (TransactionElement.doctor_id). Shared by the
+     * default closing statement print and the ?report=services report.
+     */
+    private function buildServiceProviderGroups(Closing $closing): array
+    {
+        $serviceGroups = [];
+
+        foreach ($closing->transactions as $transaction) {
+            if ($transaction->income_or_expense !== 'INCOME') {
+                continue;
+            }
+            foreach ($transaction->elements as $element) {
+                // Group elements without a service under "Uncategorized"
+                // rather than dropping them — they still count toward
+                // total_income and must reconcile with the printed total.
+                $serviceName = $element->service->name ?? 'Uncategorized';
+                $doctorName = $element->doctor?->name ?? 'No Provider';
+                $doctorId = $element->doctor_id ?? 0;
+
+                if (! isset($serviceGroups[$serviceName])) {
+                    $serviceGroups[$serviceName] = [
+                        'service_name' => $serviceName,
+                        'providers' => [],
+                        'total_income' => 0,
+                    ];
+                }
+                if (! isset($serviceGroups[$serviceName]['providers'][$doctorId])) {
+                    $serviceGroups[$serviceName]['providers'][$doctorId] = [
+                        'doctor_name' => $doctorName,
+                        'doctor_id' => $doctorId,
+                        'items' => [],
+                        'total_income' => 0,
+                        'total_expense' => 0,
+                    ];
+                }
+                $serviceGroups[$serviceName]['providers'][$doctorId]['items'][] = [
+                    'transaction_number' => $transaction->tr_number,
+                    'patient_name' => $element->patient?->name ?? 'N/A',
+                    'service_recestation' => $element->serviceRecestation?->name,
+                    'amount' => $element->amount,
+                    'type' => $transaction->type,
+                    'created_at' => $transaction->created_at,
+                ];
+                $serviceGroups[$serviceName]['providers'][$doctorId]['total_income'] += $element->amount;
+                $serviceGroups[$serviceName]['total_income'] += $element->amount;
+            }
+        }
+
+        foreach ($serviceGroups as &$group) {
+            $group['providers'] = array_values($group['providers']);
+        }
+        unset($group);
+
+        return array_values($serviceGroups);
     }
 
     /**
@@ -325,50 +430,8 @@ class ClosingStatementPdfPrintController extends Controller
 
         // Build services data grouped by Service → Service Provider, with expenses paid
         if ($report === 'services') {
-            // Group income by service → doctor
-            $serviceGroups = [];
-            $totalServiceIncome = 0;
-            foreach ($closing->transactions as $transaction) {
-                if ($transaction->income_or_expense !== 'INCOME') {
-                    continue;
-                }
-                foreach ($transaction->elements as $element) {
-                    if (! $element->service) {
-                        continue;
-                    }
-                    $serviceName = $element->service->name ?? 'Unknown Service';
-                    $doctorName = $element->doctor?->name ?? 'No Provider';
-                    $doctorId = $element->doctor_id ?? 0;
-
-                    if (! isset($serviceGroups[$serviceName])) {
-                        $serviceGroups[$serviceName] = [
-                            'service_name' => $serviceName,
-                            'providers' => [],
-                            'total_income' => 0,
-                        ];
-                    }
-                    if (! isset($serviceGroups[$serviceName]['providers'][$doctorId])) {
-                        $serviceGroups[$serviceName]['providers'][$doctorId] = [
-                            'doctor_name' => $doctorName,
-                            'doctor_id' => $doctorId,
-                            'items' => [],
-                            'total_income' => 0,
-                            'total_expense' => 0,
-                        ];
-                    }
-                    $serviceGroups[$serviceName]['providers'][$doctorId]['items'][] = [
-                        'transaction_number' => $transaction->tr_number,
-                        'patient_name' => $element->patient?->name ?? 'N/A',
-                        'service_recestation' => $element->serviceRecestation?->name,
-                        'amount' => $element->amount,
-                        'type' => $transaction->type,
-                        'created_at' => $transaction->created_at,
-                    ];
-                    $serviceGroups[$serviceName]['providers'][$doctorId]['total_income'] += $element->amount;
-                    $serviceGroups[$serviceName]['total_income'] += $element->amount;
-                    $totalServiceIncome += $element->amount;
-                }
-            }
+            $serviceGroups = $this->buildServiceProviderGroups($closing);
+            $totalServiceIncome = array_sum(array_column($serviceGroups, 'total_income'));
 
             // Collect expenses paid to each doctor from this closing
             $expensesByDoctor = [];
@@ -402,21 +465,18 @@ class ClosingStatementPdfPrintController extends Controller
 
                     // Also attach to the provider in service groups
                     foreach ($serviceGroups as &$sg) {
-                        if (isset($sg['providers'][$payedToId])) {
-                            $sg['providers'][$payedToId]['total_expense'] += $element->amount;
+                        foreach ($sg['providers'] as &$provider) {
+                            if ($provider['doctor_id'] === $payedToId) {
+                                $provider['total_expense'] += $element->amount;
+                            }
                         }
+                        unset($provider);
                     }
                     unset($sg);
                 }
             }
 
-            // Convert providers arrays from keyed to indexed
-            foreach ($serviceGroups as &$sg) {
-                $sg['providers'] = array_values($sg['providers']);
-            }
-            unset($sg);
-
-            $reportData['service_groups'] = array_values($serviceGroups);
+            $reportData['service_groups'] = $serviceGroups;
             $reportData['expenses_by_doctor'] = array_values($expensesByDoctor);
             $reportData['total_service_income'] = $totalServiceIncome;
             $reportData['total_expense_paid'] = $totalExpensePaid;

--- a/app/Http/Controllers/WebController.php
+++ b/app/Http/Controllers/WebController.php
@@ -219,8 +219,8 @@ class WebController extends Controller
     {
         $user = $request->user();
 
-        if (! $user->isAnyDoctor()) {
-            abort(403, 'Doctors only.');
+        if ($user->isPatientManager()) {
+            return $this->myPaymentsForManagedPatients($request, $user);
         }
 
         $filters = $request->only(['status', 'q', 'from', 'until']);
@@ -259,12 +259,64 @@ class WebController extends Controller
             ->sum('amount');
 
         return Inertia::render('doctor/my-payments', [
+            'mode' => 'vouchers',
             'vouchers' => $vouchers,
             'filters' => $filters,
             'totals' => [
                 'paid' => $paidTotal,
                 'pending' => $pendingTotal,
                 'total' => $paidTotal + $pendingTotal,
+            ],
+        ]);
+    }
+
+    /**
+     * Patient managers don't personally receive vouchers/petty cash, so "My
+     * Payments" shows the transactions paid by the patients they manage
+     * instead of the vouchers view every other profile gets.
+     */
+    private function myPaymentsForManagedPatients(Request $request, User $user)
+    {
+        $patientIds = PatientManager::where('user_id', $user->id)->pluck('patient_id')->filter()->values();
+
+        $filters = $request->only(['q', 'from', 'until']);
+
+        $query = Transaction::query()
+            ->whereIn('patient_id', $patientIds)
+            ->where('income_or_expense', 'INCOME')
+            ->with(['patient:id,name,ps_number', 'closing:id,ct_number']);
+
+        if (! empty($filters['q'])) {
+            $q = $filters['q'];
+            $query->where(function ($sub) use ($q) {
+                $sub->where('tr_number', 'like', "%{$q}%")
+                    ->orWhereHas('patient', fn ($p) => $p
+                        ->where('name', 'like', "%{$q}%")
+                        ->orWhere('ps_number', 'like', "%{$q}%"));
+            });
+        }
+        if (! empty($filters['from'])) {
+            $query->where('created_at', '>=', DateHelper::dayStartUtc($filters['from']));
+        }
+        if (! empty($filters['until'])) {
+            $query->where('created_at', '<=', DateHelper::dayEndUtc($filters['until']));
+        }
+
+        $transactions = $query->latest('id')->paginate(20)->withQueryString();
+
+        $paidTotal = (float) Transaction::query()
+            ->whereIn('patient_id', $patientIds)
+            ->where('income_or_expense', 'INCOME')
+            ->sum('amount');
+
+        return Inertia::render('doctor/my-payments', [
+            'mode' => 'patient_transactions',
+            'transactions' => $transactions,
+            'filters' => $filters,
+            'totals' => [
+                'paid' => $paidTotal,
+                'pending' => 0.0,
+                'total' => $paidTotal,
             ],
         ]);
     }
@@ -1436,8 +1488,13 @@ class WebController extends Controller
         return back();
     }
 
-    public function opdQueue()
+    public function opdQueue(Request $request)
     {
+        $user = $request->user();
+        if ($user->isLcdOperator() && ! $user->hasLcdAccessTo('OPD')) {
+            abort(403, 'This department display is not assigned to your account.');
+        }
+
         $type = 'OPD';
         // Optimized: top 50 per service using window function via derived table (MySQL 8+ disallows HAVING on window alias)
         $base = ServiceOrder::query()
@@ -1477,8 +1534,12 @@ class WebController extends Controller
         ]);
     }
 
-    public function indoorQueue()
+    public function indoorQueue(Request $request)
     {
+        $user = $request->user();
+        if ($user->isLcdOperator() && ! $user->hasLcdAccessTo('IND')) {
+            abort(403, 'This department display is not assigned to your account.');
+        }
 
         $type = 'IND';
         // Optimized: top 50 per service using window function via derived table (MySQL 8+ disallows HAVING on window alias)
@@ -1519,8 +1580,13 @@ class WebController extends Controller
         ]);
     }
 
-    public function emergencyQueue()
+    public function emergencyQueue(Request $request)
     {
+        $user = $request->user();
+        if ($user->isLcdOperator() && ! $user->hasLcdAccessTo('EMG')) {
+            abort(403, 'This department display is not assigned to your account.');
+        }
+
         $type = 'EMG';
         // Optimized: top 50 per service using window function via derived table (MySQL 8+ disallows HAVING on window alias)
         $base = ServiceOrder::query()
@@ -1559,8 +1625,13 @@ class WebController extends Controller
         ]);
     }
 
-    public function dentalQueue()
+    public function dentalQueue(Request $request)
     {
+        $user = $request->user();
+        if ($user->isLcdOperator() && ! $user->hasLcdAccessTo('DNT')) {
+            abort(403, 'This department display is not assigned to your account.');
+        }
+
         $type = 'DNT';
         // Optimized: top 50 per service using window function via derived table (MySQL 8+ disallows HAVING on window alias)
         $base = ServiceOrder::query()
@@ -1599,8 +1670,13 @@ class WebController extends Controller
         ]);
     }
 
-    public function laboratoryQueue()
+    public function laboratoryQueue(Request $request)
     {
+        $user = $request->user();
+        if ($user->isLcdOperator() && ! $user->hasLcdAccessTo('PTH')) {
+            abort(403, 'This department display is not assigned to your account.');
+        }
+
         $type = 'PTH';
         // Optimized: top 50 per service using window function via derived table (MySQL 8+ disallows HAVING on window alias)
         $base = ServiceOrder::query()
@@ -1639,8 +1715,13 @@ class WebController extends Controller
         ]);
     }
 
-    public function ultrasoundQueue()
+    public function ultrasoundQueue(Request $request)
     {
+        $user = $request->user();
+        if ($user->isLcdOperator() && ! $user->hasLcdAccessTo('ULT')) {
+            abort(403, 'This department display is not assigned to your account.');
+        }
+
         $type = 'ULT';
         // Optimized: top 50 per service using window function via derived table (MySQL 8+ disallows HAVING on window alias)
         $base = ServiceOrder::query()
@@ -1679,14 +1760,21 @@ class WebController extends Controller
         ]);
     }
 
-    public function radiologyQueue()
+    public function radiologyQueue(Request $request)
     {
-        $type = 'RAD';
+        $user = $request->user();
+        if ($user->isLcdOperator() && ! $user->hasLcdAccessTo('XRAY')) {
+            abort(403, 'This department display is not assigned to your account.');
+        }
+
+        // Orders are seeded with the canonical 'XRAY' department slug, but
+        // legacy rows may still carry 'RAD' — match both, same as XrayController.
+        $types = ['XRAY', 'RAD'];
         // Optimized: top 50 per service using window function via derived table (MySQL 8+ disallows HAVING on window alias)
         $base = ServiceOrder::query()
             ->select(['id', 'service_id', 'patient_id', 'created_at', 'status', 'type', 'so_number'])
             ->selectRaw('ROW_NUMBER() OVER (PARTITION BY service_id ORDER BY created_at ASC) AS rn')
-            ->where('type', $type)
+            ->whereIn('type', $types)
             ->whereIn('status', ['open', 'in-progress', 'OPEN', 'IN-PROGRESS']);
 
         // Filter by rn in an outer query

--- a/app/Models/LcdDentalOperator.php
+++ b/app/Models/LcdDentalOperator.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class LcdDentalOperator extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'authority',
+    ];
+}

--- a/app/Models/LcdEmergencyOperator.php
+++ b/app/Models/LcdEmergencyOperator.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class LcdEmergencyOperator extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'authority',
+    ];
+}

--- a/app/Models/LcdIndOperator.php
+++ b/app/Models/LcdIndOperator.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class LcdIndOperator extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'authority',
+    ];
+}

--- a/app/Models/LcdLaboratoryOperator.php
+++ b/app/Models/LcdLaboratoryOperator.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class LcdLaboratoryOperator extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'authority',
+    ];
+}

--- a/app/Models/LcdOpdOperator.php
+++ b/app/Models/LcdOpdOperator.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class LcdOpdOperator extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'authority',
+    ];
+}

--- a/app/Models/LcdUltrasoundOperator.php
+++ b/app/Models/LcdUltrasoundOperator.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class LcdUltrasoundOperator extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'authority',
+    ];
+}

--- a/app/Models/LcdXrayOperator.php
+++ b/app/Models/LcdXrayOperator.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class LcdXrayOperator extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'authority',
+    ];
+}

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -128,6 +128,18 @@ class Transaction extends Model
         return $this->hasOne(Receaveable::class, 'transaction_id');
     }
 
+    /**
+     * The receivable this transaction settles, when this transaction is a
+     * receivable collection payment (see WebController::receaveablesPayment()).
+     * The inverse of receaveable() — that one is the receivable this
+     * transaction originated, this one is the receivable this transaction
+     * pays down.
+     */
+    public function settledReceaveable()
+    {
+        return $this->belongsTo(Receaveable::class, 'receaveable_id');
+    }
+
     public function closing()
     {
         return $this->belongsTo(Closing::class, 'closing_id');

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -112,6 +112,13 @@ class User extends Authenticatable implements FilamentUser
             'xray_technician' => $this->xrayTechnicianProfiles,
             'nursing_staff' => $this->nursingStaffProfiles,
             'patient_manager' => $this->patientManagerProfiles,
+            'lcd_opd' => $this->lcdOpdProfiles,
+            'lcd_ind' => $this->lcdIndProfiles,
+            'lcd_emergency' => $this->lcdEmergencyProfiles,
+            'lcd_dental' => $this->lcdDentalProfiles,
+            'lcd_laboratory' => $this->lcdLaboratoryProfiles,
+            'lcd_ultrasound' => $this->lcdUltrasoundProfiles,
+            'lcd_xray' => $this->lcdXrayProfiles,
         ];
     }
 
@@ -181,6 +188,48 @@ class User extends Authenticatable implements FilamentUser
         return $this->hasMany(PatientManager::class);
     }
 
+    public function lcdOpdProfiles()
+    {
+
+        return $this->hasMany(LcdOpdOperator::class);
+    }
+
+    public function lcdIndProfiles()
+    {
+
+        return $this->hasMany(LcdIndOperator::class);
+    }
+
+    public function lcdEmergencyProfiles()
+    {
+
+        return $this->hasMany(LcdEmergencyOperator::class);
+    }
+
+    public function lcdDentalProfiles()
+    {
+
+        return $this->hasMany(LcdDentalOperator::class);
+    }
+
+    public function lcdLaboratoryProfiles()
+    {
+
+        return $this->hasMany(LcdLaboratoryOperator::class);
+    }
+
+    public function lcdUltrasoundProfiles()
+    {
+
+        return $this->hasMany(LcdUltrasoundOperator::class);
+    }
+
+    public function lcdXrayProfiles()
+    {
+
+        return $this->hasMany(LcdXrayOperator::class);
+    }
+
     // ─── Role helpers ────────────────────────────────────────────────────────
 
     public function isAdmin(): bool
@@ -227,6 +276,54 @@ class User extends Authenticatable implements FilamentUser
         return $this->patientManagerProfiles()->exists();
     }
 
+    /**
+     * Maps a ServiceDepartment slug to the relation name for the LCD
+     * (department queue display) profile scoped to that department.
+     *
+     * @var array<string, string>
+     */
+    public const LCD_DEPARTMENT_RELATIONS = [
+        'OPD' => 'lcdOpdProfiles',
+        'IND' => 'lcdIndProfiles',
+        'EMG' => 'lcdEmergencyProfiles',
+        'DNT' => 'lcdDentalProfiles',
+        'PTH' => 'lcdLaboratoryProfiles',
+        'ULT' => 'lcdUltrasoundProfiles',
+        'XRAY' => 'lcdXrayProfiles',
+    ];
+
+    public function isLcdOperator(): bool
+    {
+        foreach (self::LCD_DEPARTMENT_RELATIONS as $relation) {
+            if ($this->{$relation}()->exists()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function hasLcdAccessTo(string $departmentSlug): bool
+    {
+        $relation = self::LCD_DEPARTMENT_RELATIONS[$departmentSlug] ?? null;
+
+        return $relation !== null && $this->{$relation}()->exists();
+    }
+
+    /**
+     * Department slugs (ServiceDepartment.slug values) this user operates
+     * an LCD queue display for.
+     *
+     * @return array<int, string>
+     */
+    public function lcdDepartmentSlugs(): array
+    {
+        return array_values(array_filter(
+            array_keys(self::LCD_DEPARTMENT_RELATIONS),
+            fn (string $slug): bool => $this->hasLcdAccessTo($slug)
+        ));
+    }
+
     public function hasAnyProfile(): bool
     {
         return $this->isAdmin()
@@ -234,7 +331,8 @@ class User extends Authenticatable implements FilamentUser
             || $this->isReceptionist()
             || $this->isAnyDoctor()
             || $this->isPatientManager()
-            || $this->nursingStaffProfiles()->exists();
+            || $this->nursingStaffProfiles()->exists()
+            || $this->isLcdOperator();
     }
 
     /**

--- a/database/factories/LcdDentalOperatorFactory.php
+++ b/database/factories/LcdDentalOperatorFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\LcdDentalOperator;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class LcdDentalOperatorFactory extends Factory
+{
+    protected $model = LcdDentalOperator::class;
+
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+        ];
+    }
+}

--- a/database/factories/LcdEmergencyOperatorFactory.php
+++ b/database/factories/LcdEmergencyOperatorFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\LcdEmergencyOperator;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class LcdEmergencyOperatorFactory extends Factory
+{
+    protected $model = LcdEmergencyOperator::class;
+
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+        ];
+    }
+}

--- a/database/factories/LcdIndOperatorFactory.php
+++ b/database/factories/LcdIndOperatorFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\LcdIndOperator;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class LcdIndOperatorFactory extends Factory
+{
+    protected $model = LcdIndOperator::class;
+
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+        ];
+    }
+}

--- a/database/factories/LcdLaboratoryOperatorFactory.php
+++ b/database/factories/LcdLaboratoryOperatorFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\LcdLaboratoryOperator;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class LcdLaboratoryOperatorFactory extends Factory
+{
+    protected $model = LcdLaboratoryOperator::class;
+
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+        ];
+    }
+}

--- a/database/factories/LcdOpdOperatorFactory.php
+++ b/database/factories/LcdOpdOperatorFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\LcdOpdOperator;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class LcdOpdOperatorFactory extends Factory
+{
+    protected $model = LcdOpdOperator::class;
+
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+        ];
+    }
+}

--- a/database/factories/LcdUltrasoundOperatorFactory.php
+++ b/database/factories/LcdUltrasoundOperatorFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\LcdUltrasoundOperator;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class LcdUltrasoundOperatorFactory extends Factory
+{
+    protected $model = LcdUltrasoundOperator::class;
+
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+        ];
+    }
+}

--- a/database/factories/LcdXrayOperatorFactory.php
+++ b/database/factories/LcdXrayOperatorFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\LcdXrayOperator;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class LcdXrayOperatorFactory extends Factory
+{
+    protected $model = LcdXrayOperator::class;
+
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+        ];
+    }
+}

--- a/database/migrations/2026_07_31_000000_create_lcd_operator_profile_tables.php
+++ b/database/migrations/2026_07_31_000000_create_lcd_operator_profile_tables.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $tables = [
+            'lcd_opd_operators',
+            'lcd_ind_operators',
+            'lcd_emergency_operators',
+            'lcd_dental_operators',
+            'lcd_laboratory_operators',
+            'lcd_ultrasound_operators',
+            'lcd_xray_operators',
+        ];
+
+        foreach ($tables as $table) {
+            Schema::create($table, function (Blueprint $table) {
+                $table->id();
+                $table->foreignId('user_id')->constrained('users')->onDelete('cascade');
+                $table->string('authority')->default('operator')->comment('operator, supervisor');
+                $table->timestamps();
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('lcd_xray_operators');
+        Schema::dropIfExists('lcd_ultrasound_operators');
+        Schema::dropIfExists('lcd_laboratory_operators');
+        Schema::dropIfExists('lcd_dental_operators');
+        Schema::dropIfExists('lcd_emergency_operators');
+        Schema::dropIfExists('lcd_ind_operators');
+        Schema::dropIfExists('lcd_opd_operators');
+    }
+};

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -70,6 +70,13 @@ class RolesAndPermissionsSeeder extends Seeder
             'xray_technician' => ['patient.view', 'service_order.view'],
             'nursing_staff' => ['patient.view', 'service_order.view'],
             'patient_manager' => ['patient.view', 'patient.create', 'patient.edit'],
+            'lcd_opd' => ['patient.view', 'service_order.view'],
+            'lcd_ind' => ['patient.view', 'service_order.view'],
+            'lcd_emergency' => ['patient.view', 'service_order.view'],
+            'lcd_dental' => ['patient.view', 'service_order.view'],
+            'lcd_laboratory' => ['patient.view', 'service_order.view'],
+            'lcd_ultrasound' => ['patient.view', 'service_order.view'],
+            'lcd_xray' => ['patient.view', 'service_order.view'],
         ];
 
         foreach ($roles as $roleName => $permissions) {
@@ -122,6 +129,34 @@ class RolesAndPermissionsSeeder extends Seeder
 
             if ($user->patientManagerProfiles()->exists()) {
                 $assignedRoles[] = 'patient_manager';
+            }
+
+            if ($user->lcdOpdProfiles()->exists()) {
+                $assignedRoles[] = 'lcd_opd';
+            }
+
+            if ($user->lcdIndProfiles()->exists()) {
+                $assignedRoles[] = 'lcd_ind';
+            }
+
+            if ($user->lcdEmergencyProfiles()->exists()) {
+                $assignedRoles[] = 'lcd_emergency';
+            }
+
+            if ($user->lcdDentalProfiles()->exists()) {
+                $assignedRoles[] = 'lcd_dental';
+            }
+
+            if ($user->lcdLaboratoryProfiles()->exists()) {
+                $assignedRoles[] = 'lcd_laboratory';
+            }
+
+            if ($user->lcdUltrasoundProfiles()->exists()) {
+                $assignedRoles[] = 'lcd_ultrasound';
+            }
+
+            if ($user->lcdXrayProfiles()->exists()) {
+                $assignedRoles[] = 'lcd_xray';
             }
 
             if (! empty($assignedRoles)) {

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -96,6 +96,49 @@ export function AppSidebar() {
         user?.profiles?.patient_manager &&
         user?.profiles?.patient_manager.length > 0;
 
+    const haveLcdOpdProfile =
+        user?.profiles?.lcd_opd && user?.profiles?.lcd_opd.length > 0;
+    const haveLcdIndProfile =
+        user?.profiles?.lcd_ind && user?.profiles?.lcd_ind.length > 0;
+    const haveLcdEmergencyProfile =
+        user?.profiles?.lcd_emergency &&
+        user?.profiles?.lcd_emergency.length > 0;
+    const haveLcdDentalProfile =
+        user?.profiles?.lcd_dental && user?.profiles?.lcd_dental.length > 0;
+    const haveLcdLaboratoryProfile =
+        user?.profiles?.lcd_laboratory &&
+        user?.profiles?.lcd_laboratory.length > 0;
+    const haveLcdUltrasoundProfile =
+        user?.profiles?.lcd_ultrasound &&
+        user?.profiles?.lcd_ultrasound.length > 0;
+    const haveLcdXrayProfile =
+        user?.profiles?.lcd_xray && user?.profiles?.lcd_xray.length > 0;
+
+    const haveAnyDoctorWorkProfile =
+        haveOPDDoctorProfile ||
+        haveIndoorDoctorProfile ||
+        haveEmergencyDoctorProfile ||
+        haveDentistProfile ||
+        haveUltrasoundDoctorProfile ||
+        haveXrayDoctorProfile;
+
+    // My Payments is open to every profile type (see WebController::myPayments) —
+    // used to gate the "My Work" section and the My Payments link specifically.
+    const haveAnyProfileAtAll =
+        haveAnyDoctorWorkProfile ||
+        haveAdminProfile ||
+        haveAccountantProfile ||
+        haveReceptionistProfile ||
+        haveNursingProfile ||
+        havePatientManagerProfile ||
+        haveLcdOpdProfile ||
+        haveLcdIndProfile ||
+        haveLcdEmergencyProfile ||
+        haveLcdDentalProfile ||
+        haveLcdLaboratoryProfile ||
+        haveLcdUltrasoundProfile ||
+        haveLcdXrayProfile;
+
     const adminMenuItems: NavItem[] = [];
 
     if (haveAccountantProfile) {
@@ -299,28 +342,27 @@ export function AppSidebar() {
                         </SidebarMenuItem>
                     )}
                 </SidebarMenu>
-                {(haveOPDDoctorProfile ||
-                    haveIndoorDoctorProfile ||
-                    haveEmergencyDoctorProfile ||
-                    haveDentistProfile ||
-                    haveUltrasoundDoctorProfile ||
-                    haveXrayDoctorProfile) && (
+                {haveAnyProfileAtAll && (
                     <SidebarMenu className="px-2">
                         <span className="sidebar-menu-label text-sm text-[#06df72]">
                             My Work
                         </span>
-                        <SidebarMenuItem>
-                            <SidebarMenuButton
-                                asChild
-                                isActive={page.url.startsWith(myPatients().url)}
-                                tooltip={{ children: 'My Patients' }}
-                            >
-                                <Link href={myPatients().url} prefetch>
-                                    <Users />
-                                    <span>My Patients</span>
-                                </Link>
-                            </SidebarMenuButton>
-                        </SidebarMenuItem>
+                        {haveAnyDoctorWorkProfile && (
+                            <SidebarMenuItem>
+                                <SidebarMenuButton
+                                    asChild
+                                    isActive={page.url.startsWith(
+                                        myPatients().url,
+                                    )}
+                                    tooltip={{ children: 'My Patients' }}
+                                >
+                                    <Link href={myPatients().url} prefetch>
+                                        <Users />
+                                        <span>My Patients</span>
+                                    </Link>
+                                </SidebarMenuButton>
+                            </SidebarMenuItem>
+                        )}
                         <SidebarMenuItem>
                             <SidebarMenuButton
                                 asChild
@@ -470,7 +512,8 @@ export function AppSidebar() {
                         haveAccountantProfile ||
                         haveNursingProfile ||
                         haveEmergencyDoctorProfile ||
-                        haveOPDDoctorProfile) && (
+                        haveOPDDoctorProfile ||
+                        haveLcdOpdProfile) && (
                         <SidebarMenuItem>
                             <SidebarMenuButton
                                 asChild
@@ -493,7 +536,8 @@ export function AppSidebar() {
                         haveIndoorDoctorProfile ||
                         haveDentistProfile ||
                         haveUltrasoundDoctorProfile ||
-                        haveXrayDoctorProfile) && (
+                        haveXrayDoctorProfile ||
+                        haveLcdIndProfile) && (
                         <SidebarMenuItem>
                             <SidebarMenuButton
                                 asChild
@@ -516,7 +560,8 @@ export function AppSidebar() {
                         haveIndoorDoctorProfile ||
                         haveDentistProfile ||
                         haveUltrasoundDoctorProfile ||
-                        haveXrayDoctorProfile) && (
+                        haveXrayDoctorProfile ||
+                        haveLcdEmergencyProfile) && (
                         <SidebarMenuItem>
                             <SidebarMenuButton
                                 asChild
@@ -547,7 +592,8 @@ export function AppSidebar() {
                         haveIndoorDoctorProfile ||
                         haveDentistProfile ||
                         haveUltrasoundDoctorProfile ||
-                        haveXrayDoctorProfile) && (
+                        haveXrayDoctorProfile ||
+                        haveLcdDentalProfile) && (
                         <SidebarMenuItem>
                             <SidebarMenuButton
                                 asChild
@@ -573,7 +619,8 @@ export function AppSidebar() {
                         haveIndoorDoctorProfile ||
                         haveDentistProfile ||
                         haveUltrasoundDoctorProfile ||
-                        haveXrayDoctorProfile) && (
+                        haveXrayDoctorProfile ||
+                        haveLcdLaboratoryProfile) && (
                         <SidebarMenuItem>
                             <SidebarMenuButton
                                 asChild
@@ -604,7 +651,8 @@ export function AppSidebar() {
                         haveIndoorDoctorProfile ||
                         haveDentistProfile ||
                         haveUltrasoundDoctorProfile ||
-                        haveXrayDoctorProfile) && (
+                        haveXrayDoctorProfile ||
+                        haveLcdUltrasoundProfile) && (
                         <SidebarMenuItem>
                             <SidebarMenuButton
                                 asChild
@@ -635,7 +683,8 @@ export function AppSidebar() {
                         haveIndoorDoctorProfile ||
                         haveDentistProfile ||
                         haveUltrasoundDoctorProfile ||
-                        haveXrayDoctorProfile) && (
+                        haveXrayDoctorProfile ||
+                        haveLcdXrayProfile) && (
                         <SidebarMenuItem>
                             <SidebarMenuButton
                                 asChild

--- a/resources/js/pages/doctor/my-payments.tsx
+++ b/resources/js/pages/doctor/my-payments.tsx
@@ -21,6 +21,16 @@ type VoucherRow = {
     };
 };
 
+type PatientTransactionRow = {
+    id: number;
+    tr_number: string;
+    type: string;
+    amount: number;
+    created_at: string;
+    patient?: { id: number; name: string; ps_number: string };
+    closing?: { id: number; ct_number: string };
+};
+
 type Paginated<T> = {
     data: T[];
     current_page: number;
@@ -30,7 +40,9 @@ type Paginated<T> = {
 };
 
 type Props = {
-    vouchers: Paginated<VoucherRow>;
+    mode?: 'vouchers' | 'patient_transactions';
+    vouchers?: Paginated<VoucherRow>;
+    transactions?: Paginated<PatientTransactionRow>;
     filters: { q?: string; from?: string; until?: string };
     totals: { paid: number; pending: number; total: number };
     [key: string]: unknown;
@@ -42,7 +54,10 @@ const breadcrumbs: BreadcrumbItem[] = [
 ];
 
 export default function MyPayments() {
-    const { vouchers, filters, totals } = usePage<Props>().props;
+    const { mode = 'vouchers', vouchers, transactions, filters, totals } =
+        usePage<Props>().props;
+    const isPatientTransactions = mode === 'patient_transactions';
+    const rows = isPatientTransactions ? transactions! : vouchers!;
     const [form, setForm] = useState(filters);
 
     const apply = () => {
@@ -71,8 +86,9 @@ export default function MyPayments() {
                                 My Payments
                             </h1>
                             <p className="text-xs text-slate-500">
-                                Expense vouchers issued to you ({vouchers.total}{' '}
-                                total).
+                                {isPatientTransactions
+                                    ? `Transactions paid by patients you manage (${rows.total} total).`
+                                    : `Expense vouchers issued to you (${rows.total} total).`}
                             </p>
                         </div>
                     </div>
@@ -118,7 +134,11 @@ export default function MyPayments() {
                                     onKeyDown={(e) =>
                                         e.key === 'Enter' && apply()
                                     }
-                                    placeholder="Voucher #, notes…"
+                                    placeholder={
+                                        isPatientTransactions
+                                            ? 'Transaction #, patient name, PS #…'
+                                            : 'Voucher #, notes…'
+                                    }
                                     className="w-full rounded-lg border border-slate-200 bg-slate-50 py-2 pr-3 pl-9 text-sm focus:bg-white focus:ring-2 focus:ring-emerald-100 focus:outline-none dark:border-gray-700 dark:bg-gray-800"
                                 />
                             </div>
@@ -179,109 +199,177 @@ export default function MyPayments() {
                     <div className="overflow-x-auto">
                         <table className="w-full text-sm">
                             <thead className="bg-slate-50 text-xs font-semibold tracking-wide text-slate-600 uppercase dark:bg-gray-800 dark:text-slate-300">
-                                <tr>
-                                    <th className="px-4 py-2 text-left">
-                                        Date
-                                    </th>
-                                    <th className="px-4 py-2 text-left">
-                                        Voucher #
-                                    </th>
-                                    <th className="px-4 py-2 text-left">
-                                        Service Order
-                                    </th>
-                                    <th className="px-4 py-2 text-left">
-                                        Category
-                                    </th>
-                                    <th className="px-4 py-2 text-right">
-                                        Amount
-                                    </th>
-                                    <th className="px-4 py-2 text-left">
-                                        Status
-                                    </th>
-                                </tr>
+                                {isPatientTransactions ? (
+                                    <tr>
+                                        <th className="px-4 py-2 text-left">
+                                            Date
+                                        </th>
+                                        <th className="px-4 py-2 text-left">
+                                            Transaction #
+                                        </th>
+                                        <th className="px-4 py-2 text-left">
+                                            Patient
+                                        </th>
+                                        <th className="px-4 py-2 text-left">
+                                            Method
+                                        </th>
+                                        <th className="px-4 py-2 text-right">
+                                            Amount
+                                        </th>
+                                    </tr>
+                                ) : (
+                                    <tr>
+                                        <th className="px-4 py-2 text-left">
+                                            Date
+                                        </th>
+                                        <th className="px-4 py-2 text-left">
+                                            Voucher #
+                                        </th>
+                                        <th className="px-4 py-2 text-left">
+                                            Service Order
+                                        </th>
+                                        <th className="px-4 py-2 text-left">
+                                            Category
+                                        </th>
+                                        <th className="px-4 py-2 text-right">
+                                            Amount
+                                        </th>
+                                        <th className="px-4 py-2 text-left">
+                                            Status
+                                        </th>
+                                    </tr>
+                                )}
                             </thead>
                             <tbody>
-                                {vouchers.data.length === 0 && (
+                                {rows.data.length === 0 && (
                                     <tr>
                                         <td
-                                            colSpan={6}
+                                            colSpan={isPatientTransactions ? 5 : 6}
                                             className="px-4 py-12 text-center text-sm text-slate-500"
                                         >
-                                            No payment vouchers yet.
+                                            {isPatientTransactions
+                                                ? 'No transactions yet for your managed patients.'
+                                                : 'No payment vouchers yet.'}
                                         </td>
                                     </tr>
                                 )}
-                                {vouchers.data.map((v) => (
-                                    <tr
-                                        key={v.id}
-                                        className="border-t border-slate-100 hover:bg-slate-50 dark:border-gray-800 dark:hover:bg-gray-800"
-                                    >
-                                        <td className="px-4 py-2 text-xs text-slate-500">
-                                            {new Date(
-                                                v.created_at,
-                                            ).toLocaleDateString()}
-                                        </td>
-                                        <td className="px-4 py-2 font-mono text-xs">
-                                            {v.vc_number}
-                                        </td>
-                                        <td className="px-4 py-2 text-xs">
-                                            {v.service_order ? (
-                                                <>
-                                                    <div className="font-mono">
-                                                        {
-                                                            v.service_order
-                                                                .so_number
-                                                        }
-                                                    </div>
-                                                    <div className="text-slate-500">
-                                                        {
-                                                            v.service_order
-                                                                .patient?.name
-                                                        }
-                                                    </div>
-                                                </>
-                                            ) : (
-                                                <span className="text-slate-400">
-                                                    —
-                                                </span>
-                                            )}
-                                        </td>
-                                        <td className="px-4 py-2 text-xs text-slate-600">
-                                            {v.exp_category?.name ?? '—'}
-                                        </td>
-                                        <td className="px-4 py-2 text-right font-semibold text-slate-800 dark:text-slate-100">
-                                            <Currency
-                                                value={Number(v.amount)}
-                                            />
-                                        </td>
-                                        <td className="px-4 py-2">
-                                            <span
-                                                className={clsx(
-                                                    'rounded-full px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase',
-                                                    v.status === 'payed'
-                                                        ? 'bg-emerald-100 text-emerald-700'
-                                                        : 'bg-amber-100 text-amber-700',
-                                                )}
-                                            >
-                                                {v.status === 'payed'
-                                                    ? 'PAID'
-                                                    : 'PENDING'}
-                                            </span>
-                                        </td>
-                                    </tr>
-                                ))}
+                                {isPatientTransactions
+                                    ? transactions!.data.map((t) => (
+                                          <tr
+                                              key={t.id}
+                                              className="border-t border-slate-100 hover:bg-slate-50 dark:border-gray-800 dark:hover:bg-gray-800"
+                                          >
+                                              <td className="px-4 py-2 text-xs text-slate-500">
+                                                  {new Date(
+                                                      t.created_at,
+                                                  ).toLocaleDateString()}
+                                              </td>
+                                              <td className="px-4 py-2 font-mono text-xs">
+                                                  {t.tr_number}
+                                              </td>
+                                              <td className="px-4 py-2 text-xs">
+                                                  {t.patient ? (
+                                                      <>
+                                                          <div>
+                                                              {t.patient.name}
+                                                          </div>
+                                                          <div className="font-mono text-slate-500">
+                                                              {
+                                                                  t.patient
+                                                                      .ps_number
+                                                              }
+                                                          </div>
+                                                      </>
+                                                  ) : (
+                                                      <span className="text-slate-400">
+                                                          —
+                                                      </span>
+                                                  )}
+                                              </td>
+                                              <td className="px-4 py-2 text-xs text-slate-600">
+                                                  {t.type}
+                                              </td>
+                                              <td className="px-4 py-2 text-right font-semibold text-slate-800 dark:text-slate-100">
+                                                  <Currency
+                                                      value={Number(t.amount)}
+                                                  />
+                                              </td>
+                                          </tr>
+                                      ))
+                                    : vouchers!.data.map((v) => (
+                                          <tr
+                                              key={v.id}
+                                              className="border-t border-slate-100 hover:bg-slate-50 dark:border-gray-800 dark:hover:bg-gray-800"
+                                          >
+                                              <td className="px-4 py-2 text-xs text-slate-500">
+                                                  {new Date(
+                                                      v.created_at,
+                                                  ).toLocaleDateString()}
+                                              </td>
+                                              <td className="px-4 py-2 font-mono text-xs">
+                                                  {v.vc_number}
+                                              </td>
+                                              <td className="px-4 py-2 text-xs">
+                                                  {v.service_order ? (
+                                                      <>
+                                                          <div className="font-mono">
+                                                              {
+                                                                  v
+                                                                      .service_order
+                                                                      .so_number
+                                                              }
+                                                          </div>
+                                                          <div className="text-slate-500">
+                                                              {
+                                                                  v
+                                                                      .service_order
+                                                                      .patient
+                                                                      ?.name
+                                                              }
+                                                          </div>
+                                                      </>
+                                                  ) : (
+                                                      <span className="text-slate-400">
+                                                          —
+                                                      </span>
+                                                  )}
+                                              </td>
+                                              <td className="px-4 py-2 text-xs text-slate-600">
+                                                  {v.exp_category?.name ?? '—'}
+                                              </td>
+                                              <td className="px-4 py-2 text-right font-semibold text-slate-800 dark:text-slate-100">
+                                                  <Currency
+                                                      value={Number(v.amount)}
+                                                  />
+                                              </td>
+                                              <td className="px-4 py-2">
+                                                  <span
+                                                      className={clsx(
+                                                          'rounded-full px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase',
+                                                          v.status === 'payed'
+                                                              ? 'bg-emerald-100 text-emerald-700'
+                                                              : 'bg-amber-100 text-amber-700',
+                                                      )}
+                                                  >
+                                                      {v.status === 'payed'
+                                                          ? 'PAID'
+                                                          : 'PENDING'}
+                                                  </span>
+                                              </td>
+                                          </tr>
+                                      ))}
                             </tbody>
                         </table>
                     </div>
 
-                    {vouchers.last_page > 1 && (
+                    {rows.last_page > 1 && (
                         <div className="flex items-center justify-between border-t border-slate-100 px-4 py-2 text-xs dark:border-gray-800">
                             <p className="text-slate-500">
-                                Page {vouchers.current_page} of{' '}
-                                {vouchers.last_page} · {vouchers.total} total
+                                Page {rows.current_page} of {rows.last_page} ·{' '}
+                                {rows.total} total
                             </p>
                             <div className="flex gap-1">
-                                {vouchers.links.map((l, i) => (
+                                {rows.links.map((l, i) => (
                                     <Link
                                         key={i}
                                         href={l.url ?? '#'}

--- a/resources/js/pages/doctor/my-payments.tsx
+++ b/resources/js/pages/doctor/my-payments.tsx
@@ -54,8 +54,13 @@ const breadcrumbs: BreadcrumbItem[] = [
 ];
 
 export default function MyPayments() {
-    const { mode = 'vouchers', vouchers, transactions, filters, totals } =
-        usePage<Props>().props;
+    const {
+        mode = 'vouchers',
+        vouchers,
+        transactions,
+        filters,
+        totals,
+    } = usePage<Props>().props;
     const isPatientTransactions = mode === 'patient_transactions';
     const rows = isPatientTransactions ? transactions! : vouchers!;
     const [form, setForm] = useState(filters);
@@ -244,7 +249,9 @@ export default function MyPayments() {
                                 {rows.data.length === 0 && (
                                     <tr>
                                         <td
-                                            colSpan={isPatientTransactions ? 5 : 6}
+                                            colSpan={
+                                                isPatientTransactions ? 5 : 6
+                                            }
                                             className="px-4 py-12 text-center text-sm text-slate-500"
                                         >
                                             {isPatientTransactions

--- a/resources/views/pdfs/closing-statement/closing-statement-normal.blade.php
+++ b/resources/views/pdfs/closing-statement/closing-statement-normal.blade.php
@@ -33,46 +33,59 @@
         </div>
     </div>
 
-    {{-- Income Transactions --}}
-    @if(count($transactions['income']) > 0)
-    <div class="section-title">Income Transactions ({{ $summary['income_count'] }})</div>
-    <table>
-        <thead>
-            <tr>
-                <th style="width: 42px;">Time</th>
-                <th>Patient</th>
-                <th>Service</th>
-                <th class="amount" style="width: 80px;">Amount</th>
-            </tr>
-        </thead>
-        <tbody>
-            @foreach($transactions['income'] as $transaction)
-                @foreach($transaction['elements'] as $element)
-                <tr>
-                    <td>{{ \App\Helpers\DateHelper::pdfFormat($element['created_at'], 'H:i') }}</td>
-                    <td>
-                        @if($element['patient_name'])
-                            {{ $element['patient_name'] }}
-                            @if($element['patient_ps_number'])
-                                <br><span class="text-muted mono">{{ $element['patient_ps_number'] }}</span>
-                            @endif
-                        @else
-                            -
-                        @endif
-                    </td>
-                    <td>{{ $element['service_name'] }}</td>
-                    <td class="amount">{{ number_format($element['amount'], 2) }}</td>
-                </tr>
-                @endforeach
+    {{-- Income Transactions — grouped by Service → Service Provider --}}
+    @if(count($service_groups) > 0)
+        <div class="section-title">Income Transactions ({{ $summary['income_count'] }})</div>
+        @foreach($service_groups as $group)
+            <div class="sub-section">
+                {{ $group['service_name'] }}
+                <span style="float: right; font-size: 10px; font-weight: 400;">
+                    Service Total: {{ number_format($group['total_income'], 2) }}
+                </span>
+            </div>
+
+            @foreach($group['providers'] as $provider)
+                <table>
+                    <thead>
+                        <tr>
+                            <th colspan="4" style="background: #ffffff; text-transform: none; font-size: 10px; font-weight: 600; padding: 3px 8px;">
+                                {{ $provider['doctor_name'] }}
+                            </th>
+                        </tr>
+                        <tr>
+                            <th style="width: 42px;">Time</th>
+                            <th>Patient</th>
+                            <th style="width: 60px;">Method</th>
+                            <th class="amount" style="width: 80px;">Amount</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach($provider['items'] as $item)
+                        <tr>
+                            <td>{{ \App\Helpers\DateHelper::pdfFormat($item['created_at'], 'H:i') }}</td>
+                            <td>{{ $item['patient_name'] }}</td>
+                            <td><span class="mono">{{ $item['type'] }}</span></td>
+                            <td class="amount">{{ number_format($item['amount'], 2) }}</td>
+                        </tr>
+                        @endforeach
+                    </tbody>
+                    <tfoot>
+                        <tr class="subtotal-row">
+                            <td colspan="3" class="text-right">Subtotal &mdash; {{ $provider['doctor_name'] }}</td>
+                            <td class="amount">{{ number_format($provider['total_income'], 2) }}</td>
+                        </tr>
+                    </tfoot>
+                </table>
             @endforeach
-        </tbody>
-        <tfoot>
-            <tr class="total-row">
-                <td colspan="3" class="text-right">Total Income</td>
-                <td class="amount">{{ number_format($totals['total_income'], 2) }}</td>
-            </tr>
-        </tfoot>
-    </table>
+        @endforeach
+        <table>
+            <tbody>
+                <tr class="total-row">
+                    <td class="text-right">Total Income</td>
+                    <td class="amount" style="width: 80px;">{{ number_format($totals['total_income'], 2) }}</td>
+                </tr>
+            </tbody>
+        </table>
     @endif
 
     {{-- Expense Transactions --}}
@@ -148,6 +161,70 @@
     </table>
     @endif
 
+    {{-- Receivables Created --}}
+    @if(count($receivables['created']) > 0)
+    <div class="section-title" style="background: #7c3aed;">Receivables Created ({{ count($receivables['created']) }})</div>
+    <table>
+        <thead>
+            <tr>
+                <th style="width: 42px;">Time</th>
+                <th>Patient</th>
+                <th>Panel</th>
+                <th style="width: 80px;">Status</th>
+                <th class="amount" style="width: 80px;">Amount</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($receivables['created'] as $row)
+            <tr>
+                <td>{{ \App\Helpers\DateHelper::pdfFormat($row['created_at'], 'H:i') }}</td>
+                <td>{{ $row['patient_name'] }}</td>
+                <td>{{ $row['panel_name'] }}</td>
+                <td><span class="badge badge-purple">{{ strtoupper($row['status']) }}</span></td>
+                <td class="amount">{{ number_format($row['amount'], 2) }}</td>
+            </tr>
+            @endforeach
+        </tbody>
+        <tfoot>
+            <tr class="total-row">
+                <td colspan="4" class="text-right">Total Receivables Created</td>
+                <td class="amount">{{ number_format($totals['receivables_created_total'], 2) }}</td>
+            </tr>
+        </tfoot>
+    </table>
+    @endif
+
+    {{-- Receivables Collected --}}
+    @if(count($receivables['collected']) > 0)
+    <div class="section-title" style="background: #059669;">Receivables Collected ({{ count($receivables['collected']) }})</div>
+    <table>
+        <thead>
+            <tr>
+                <th style="width: 42px;">Time</th>
+                <th>Patient</th>
+                <th style="width: 80px;">Method</th>
+                <th class="amount" style="width: 80px;">Amount</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($receivables['collected'] as $row)
+            <tr>
+                <td>{{ \App\Helpers\DateHelper::pdfFormat($row['created_at'], 'H:i') }}</td>
+                <td>{{ $row['patient_name'] }}</td>
+                <td><span class="badge badge-green">{{ $row['method'] }}</span></td>
+                <td class="amount">{{ number_format($row['amount'], 2) }}</td>
+            </tr>
+            @endforeach
+        </tbody>
+        <tfoot>
+            <tr class="total-row">
+                <td colspan="3" class="text-right">Total Receivables Collected</td>
+                <td class="amount">{{ number_format($totals['receivables_collected_total'], 2) }}</td>
+            </tr>
+        </tfoot>
+    </table>
+    @endif
+
     {{-- Summary --}}
     @php
         $cashIncome = $totals['income_by_payment_method']['CASH'] ?? 0;
@@ -202,8 +279,20 @@
         </tr>
         @if($receivablesTotal > 0)
         <tr style="background: #faf5ff;">
-            <td>Receivables <span class="text-muted" style="font-size: 9px;">({{ $receivablesCount }} items)</span></td>
+            <td>Receivables Outstanding <span class="text-muted" style="font-size: 9px;">({{ $receivablesCount }} items)</span></td>
             <td class="amount" style="color: #7c3aed;">{{ number_format($receivablesTotal, 2) }}</td>
+        </tr>
+        @endif
+        @if($totals['receivables_created_total'] > 0)
+        <tr style="background: #faf5ff;">
+            <td>Receivables Created</td>
+            <td class="amount" style="color: #7c3aed;">{{ number_format($totals['receivables_created_total'], 2) }}</td>
+        </tr>
+        @endif
+        @if($totals['receivables_collected_total'] > 0)
+        <tr style="background: #ecfdf5;">
+            <td>Receivables Collected</td>
+            <td class="amount" style="color: #059669;">{{ number_format($totals['receivables_collected_total'], 2) }}</td>
         </tr>
         @endif
     </table>

--- a/tests/Feature/Prints/ClosingStatementReceivablesAndGroupingTest.php
+++ b/tests/Feature/Prints/ClosingStatementReceivablesAndGroupingTest.php
@@ -1,0 +1,160 @@
+<?php
+
+use App\Http\Controllers\Prints\ClosingStatementPdfPrintController;
+use App\Models\Closing;
+use App\Models\Patient;
+use App\Models\Receaveable;
+use App\Models\Service;
+use App\Models\Transaction;
+use App\Models\TransactionElement;
+use App\Models\User;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+
+function buildClosingForPrintTest(): Closing
+{
+    $closing = Closing::factory()->create();
+
+    $serviceA = Service::factory()->create(['name' => 'Consultation']);
+    $serviceB = Service::factory()->create(['name' => 'Ultrasound Scan']);
+    $doctorX = User::factory()->create(['name' => 'Dr. X']);
+    $doctorY = User::factory()->create(['name' => 'Dr. Y']);
+    $patient = Patient::factory()->create();
+
+    // Two income transactions under Service A / Dr X — should merge into one group.
+    foreach ([500, 200] as $amount) {
+        $transaction = Transaction::factory()->create([
+            'closing_id' => $closing->id,
+            'income_or_expense' => 'INCOME',
+            'amount' => $amount,
+            'orignal_amount' => $amount,
+        ]);
+        TransactionElement::factory()->create([
+            'closing_id' => $closing->id,
+            'transaction_id' => $transaction->id,
+            'service_id' => $serviceA->id,
+            'doctor_id' => $doctorX->id,
+            'amount' => $amount,
+            'orignal_amount' => $amount,
+        ]);
+    }
+
+    // One income transaction under Service B / Dr Y.
+    $txB = Transaction::factory()->create([
+        'closing_id' => $closing->id,
+        'income_or_expense' => 'INCOME',
+        'amount' => 300,
+        'orignal_amount' => 300,
+    ]);
+    TransactionElement::factory()->create([
+        'closing_id' => $closing->id,
+        'transaction_id' => $txB->id,
+        'service_id' => $serviceB->id,
+        'doctor_id' => $doctorY->id,
+        'amount' => 300,
+        'orignal_amount' => 300,
+    ]);
+
+    // One income transaction with an element that has no service — must not
+    // be dropped, should land under "Uncategorized" and still count toward totals.
+    $txNoService = Transaction::factory()->create([
+        'closing_id' => $closing->id,
+        'income_or_expense' => 'INCOME',
+        'amount' => 100,
+        'orignal_amount' => 100,
+    ]);
+    TransactionElement::factory()->create([
+        'closing_id' => $closing->id,
+        'transaction_id' => $txNoService->id,
+        'service_id' => null,
+        'doctor_id' => null,
+        'amount' => 100,
+        'orignal_amount' => 100,
+    ]);
+
+    // A receivable created during this closing (full amount not collected yet).
+    $txReceivableOrigin = Transaction::factory()->create([
+        'closing_id' => $closing->id,
+        'income_or_expense' => 'INCOME',
+        'patient_id' => $patient->id,
+        'amount' => 1000,
+        'orignal_amount' => 1000,
+    ]);
+    $receaveable = Receaveable::factory()->create([
+        'transaction_id' => $txReceivableOrigin->id,
+        'patient_id' => $patient->id,
+        'orignal_amount' => 1000,
+        'amount' => 1000,
+        'status' => 'unpaid',
+    ]);
+
+    // A settlement transaction collecting part of that receivable, within the same closing.
+    Transaction::factory()->create([
+        'closing_id' => $closing->id,
+        'income_or_expense' => 'INCOME',
+        'patient_id' => $patient->id,
+        'type' => 'CASH',
+        'amount' => 400,
+        'orignal_amount' => 400,
+        'receaveable_id' => $receaveable->id,
+    ]);
+
+    return $closing->fresh([
+        'transactions.elements.patient',
+        'transactions.elements.service',
+        'transactions.elements.doctor',
+        'transactions.elements.expenseCategory',
+        'transactions.elements.serviceRecestation',
+        'transactions.receaveable.patient',
+        'transactions.receaveable.panel',
+        'transactions.settledReceaveable.patient',
+    ]);
+}
+
+test('closing statement print groups income by service and provider, including uncategorized', function () {
+    $closing = buildClosingForPrintTest();
+
+    $controller = new ClosingStatementPdfPrintController;
+    $method = new ReflectionMethod($controller, 'prepareClosingData');
+    $data = $method->invoke($controller, $closing);
+
+    $groups = collect($data['service_groups'])->keyBy('service_name');
+
+    expect($groups->has('Consultation'))->toBeTrue()
+        ->and($groups['Consultation']['total_income'])->toBe(700.0)
+        ->and($groups['Consultation']['providers'][0]['doctor_name'])->toBe('Dr. X')
+        ->and($groups->has('Ultrasound Scan'))->toBeTrue()
+        ->and($groups['Ultrasound Scan']['total_income'])->toBe(300.0)
+        ->and($groups->has('Uncategorized'))->toBeTrue()
+        ->and($groups['Uncategorized']['total_income'])->toBe(100.0);
+});
+
+test('closing statement print reports receivables created and collected as separate totals with row-level records', function () {
+    $closing = buildClosingForPrintTest();
+
+    $controller = new ClosingStatementPdfPrintController;
+    $method = new ReflectionMethod($controller, 'prepareClosingData');
+    $data = $method->invoke($controller, $closing);
+
+    expect((float) $data['totals']['receivables_created_total'])->toBe(1000.0)
+        ->and((float) $data['totals']['receivables_collected_total'])->toBe(400.0)
+        ->and($data['receivables']['created'])->toHaveCount(1)
+        ->and((float) $data['receivables']['created'][0]['amount'])->toBe(1000.0)
+        ->and($data['receivables']['collected'])->toHaveCount(1)
+        ->and((float) $data['receivables']['collected'][0]['amount'])->toBe(400.0);
+});
+
+test('closing statement print renders successfully with grouped services and receivables', function () {
+    actingAs(User::factory()->create());
+
+    $closing = buildClosingForPrintTest();
+
+    get(route('print-closing-statement', [
+        'year' => $closing->year,
+        'month' => $closing->month,
+        'number' => $closing->number,
+    ]))
+        ->assertOk()
+        ->assertHeader('Content-Type', 'application/pdf');
+});

--- a/tests/Feature/Prints/ClosingStatementReceivablesAndGroupingTest.php
+++ b/tests/Feature/Prints/ClosingStatementReceivablesAndGroupingTest.php
@@ -122,12 +122,12 @@ test('closing statement print groups income by service and provider, including u
     $groups = collect($data['service_groups'])->keyBy('service_name');
 
     expect($groups->has('Consultation'))->toBeTrue()
-        ->and($groups['Consultation']['total_income'])->toBe(700.0)
+        ->and((float) $groups['Consultation']['total_income'])->toBe(700.0)
         ->and($groups['Consultation']['providers'][0]['doctor_name'])->toBe('Dr. X')
         ->and($groups->has('Ultrasound Scan'))->toBeTrue()
-        ->and($groups['Ultrasound Scan']['total_income'])->toBe(300.0)
+        ->and((float) $groups['Ultrasound Scan']['total_income'])->toBe(300.0)
         ->and($groups->has('Uncategorized'))->toBeTrue()
-        ->and($groups['Uncategorized']['total_income'])->toBe(100.0);
+        ->and((float) $groups['Uncategorized']['total_income'])->toBe(100.0);
 });
 
 test('closing statement print reports receivables created and collected as separate totals with row-level records', function () {

--- a/tests/Feature/Web/LcdQueueAccessTest.php
+++ b/tests/Feature/Web/LcdQueueAccessTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use App\Models\LcdOpdOperator;
+use App\Models\LcdXrayOperator;
+use App\Models\ServiceOrder;
+use App\Models\User;
+use Inertia\Testing\AssertableInertia as Assert;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+
+test('an LCD operator can view their own department queue', function () {
+    $user = User::factory()->create();
+    LcdOpdOperator::factory()->create(['user_id' => $user->id]);
+    actingAs($user);
+
+    get(route('hospital-opd-queue'))->assertOk();
+});
+
+test('an LCD operator is blocked from other departments queues', function () {
+    $user = User::factory()->create();
+    LcdOpdOperator::factory()->create(['user_id' => $user->id]);
+    actingAs($user);
+
+    get(route('hospital-emergency-queue'))->assertForbidden();
+    get(route('hospital-indoor-queue'))->assertForbidden();
+    get(route('hospital-dental-queue'))->assertForbidden();
+    get(route('hospital-laboratory-queue'))->assertForbidden();
+    get(route('hospital-ultrasound-queue'))->assertForbidden();
+    get(route('hospital-radiology-queue'))->assertForbidden();
+});
+
+test('a user with no LCD profile is not restricted on any queue route', function () {
+    actingAs(User::factory()->create());
+
+    get(route('hospital-opd-queue'))->assertOk();
+    get(route('hospital-emergency-queue'))->assertOk();
+    get(route('hospital-radiology-queue'))->assertOk();
+});
+
+test('radiology queue display shows orders of the canonical XRAY type', function () {
+    $user = User::factory()->create();
+    LcdXrayOperator::factory()->create(['user_id' => $user->id]);
+    actingAs($user);
+
+    $xrayOrder = ServiceOrder::factory()->create(['type' => 'XRAY', 'status' => 'open']);
+    $legacyRadOrder = ServiceOrder::factory()->create(['type' => 'RAD', 'status' => 'open']);
+    $otherOrder = ServiceOrder::factory()->create(['type' => 'OPD', 'status' => 'open']);
+
+    get(route('hospital-radiology-queue'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('hospital/opd-queue')
+            ->has("serviceOrdersByService.{$xrayOrder->service_id}", 1)
+            ->has("serviceOrdersByService.{$legacyRadOrder->service_id}", 1)
+            ->missing("serviceOrdersByService.{$otherOrder->service_id}")
+        );
+});

--- a/tests/Feature/Web/MyPaymentsTest.php
+++ b/tests/Feature/Web/MyPaymentsTest.php
@@ -1,0 +1,81 @@
+<?php
+
+use App\Models\ExpenseVoucher;
+use App\Models\LcdOpdOperator;
+use App\Models\NursingStaff;
+use App\Models\Patient;
+use App\Models\PatientManager;
+use App\Models\Receptionist;
+use App\Models\Transaction;
+use App\Models\User;
+use Inertia\Testing\AssertableInertia as Assert;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+
+test('a nurse can view my payments and sees their own vouchers', function () {
+    $user = User::factory()->create();
+    NursingStaff::factory()->create(['user_id' => $user->id]);
+    actingAs($user);
+
+    $ownVoucher = ExpenseVoucher::factory()->create(['payed_to' => $user->id]);
+    ExpenseVoucher::factory()->create(); // someone else's voucher
+
+    get(route('my-payments'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('doctor/my-payments')
+            ->where('mode', 'vouchers')
+            ->has('vouchers.data', 1)
+            ->where('vouchers.data.0.id', $ownVoucher->id)
+        );
+});
+
+test('a receptionist can view my payments', function () {
+    $user = User::factory()->create();
+    Receptionist::factory()->create(['user_id' => $user->id]);
+    actingAs($user);
+
+    get(route('my-payments'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page->where('mode', 'vouchers'));
+});
+
+test('an LCD operator can view my payments', function () {
+    $user = User::factory()->create();
+    LcdOpdOperator::factory()->create(['user_id' => $user->id]);
+    actingAs($user);
+
+    get(route('my-payments'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page->where('mode', 'vouchers'));
+});
+
+test('a patient manager sees transactions paid by their managed patients, not vouchers', function () {
+    $user = User::factory()->create();
+    $managedPatient = Patient::factory()->create();
+    $otherPatient = Patient::factory()->create();
+    PatientManager::factory()->create(['user_id' => $user->id, 'patient_id' => $managedPatient->id]);
+    actingAs($user);
+
+    $ownedTransaction = Transaction::factory()->create([
+        'patient_id' => $managedPatient->id,
+        'income_or_expense' => 'INCOME',
+        'amount' => 750,
+    ]);
+    Transaction::factory()->create([
+        'patient_id' => $otherPatient->id,
+        'income_or_expense' => 'INCOME',
+        'amount' => 999,
+    ]);
+
+    get(route('my-payments'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('doctor/my-payments')
+            ->where('mode', 'patient_transactions')
+            ->has('transactions.data', 1)
+            ->where('transactions.data.0.id', $ownedTransaction->id)
+            ->where('totals.paid', fn ($value) => (float) $value === 750.0)
+        );
+});


### PR DESCRIPTION
## Summary
- Add `LCD_{department}` profile types (7 tables mirroring the existing doctor-profile pattern) whose accounts see and are restricted to their own department's public queue screen (`/que/opd`, `/que/emergency`, etc.); as part of this, fixes a pre-existing bug where the radiology queue only matched `type = 'RAD'` and missed the canonical `XRAY` type.
- Open "My Payments" to every profile (previously doctors only). `patient_manager` now sees transactions paid by the patients they manage instead of vouchers/petty cash.
- CT closing-statement print (`PRINT/CT/{year}/{month}/{number}`, default view) now groups income by service → service provider instead of a flat list, and adds row-level "Receivables Created" / "Receivables Collected" tables plus their totals, alongside the existing outstanding balance.

## Test plan
- [x] New tests: `tests/Feature/Web/LcdQueueAccessTest.php`, `tests/Feature/Web/MyPaymentsTest.php`, `tests/Feature/Prints/ClosingStatementReceivablesAndGroupingTest.php` — all pass (11/11).
- [x] `vendor/bin/pint` clean on all touched PHP files.
- [x] `tsc --noEmit` clean on all touched TS/TSX files.
- [x] Full suite run twice for a stable baseline: both runs land at 44 failed / 1 skipped / 576 passed, identical duration (~483s). None of the 44 pre-existing failures touch any file in this PR (auth/CSRF, Filament resource, and decimal-cast issues that pre-date this branch — confirmed via `git stash` against clean `main` for the `UserResourceTest` subset).
- [ ] Manual UI verification (LCD queue screens, My Payments views, CT print PDF) not performed — no browser access in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)