### PR TITLE
Add configurable OPD appointment booking with priority handling

### DIFF
--- a/app/Console/Commands/ExpireNoShowAppointments.php
+++ b/app/Console/Commands/ExpireNoShowAppointments.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enum\AppointmentStatus;
+use App\Models\Appointment;
+use Illuminate\Console\Command;
+
+class ExpireNoShowAppointments extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:expire-no-show-appointments';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Mark today\'s unattended appointments as no-show and clear their draft receivable/reserved queue slot';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): void
+    {
+        $this->info('Expiring no-show appointments...');
+
+        Appointment::with('receaveable', 'serviceOrder')
+            ->where('status', AppointmentStatus::Scheduled)
+            ->whereDate('scheduled_at', now()->toDateString())
+            ->orderBy('id')
+            ->chunkById(200, function ($appointments): void {
+                foreach ($appointments as $appointment) {
+                    if ($appointment->receaveable && $appointment->receaveable->status === 'draft') {
+                        $appointment->receaveable->status = 'cancelled';
+                        $appointment->receaveable->save();
+                    }
+
+                    if ($appointment->serviceOrder && empty($appointment->serviceOrder->closed_at)) {
+                        $appointment->serviceOrder->closed_at = now();
+                        $appointment->serviceOrder->status = 'CLOSED';
+                        $appointment->serviceOrder->notes = 'Automatically closed by system: appointment no-show.';
+                        $appointment->serviceOrder->save();
+                    }
+
+                    $appointment->status = AppointmentStatus::NoShow;
+                    $appointment->save();
+                }
+
+                $this->info('Expired '.count($appointments).' no-show appointments');
+            });
+
+        $this->info('Finished expiring no-show appointments.');
+    }
+}

--- a/app/Console/Commands/MaterializeAppointments.php
+++ b/app/Console/Commands/MaterializeAppointments.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enum\AppointmentPriorityMode;
+use App\Enum\AppointmentStatus;
+use App\Models\Appointment;
+use App\Models\Patient;
+use App\Models\ServiceOrder;
+use Illuminate\Console\Command;
+
+class MaterializeAppointments extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:materialize-appointments';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create the reserved queue slot for today\'s Priority/Medium appointments';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): void
+    {
+        $this->info('Materializing today\'s appointments into the live queue...');
+
+        Appointment::with('patient', 'service.department')
+            ->where('status', AppointmentStatus::Scheduled)
+            ->whereNull('service_order_id')
+            ->whereDate('scheduled_at', now()->toDateString())
+            ->where('priority_mode', '!=', AppointmentPriorityMode::Standard->value)
+            ->orderBy('id')
+            ->chunkById(200, function ($appointments): void {
+                foreach ($appointments as $appointment) {
+                    $patient = $appointment->patient;
+                    $service = $appointment->service;
+
+                    if (! $patient || ! $service || ! $service->department) {
+                        continue;
+                    }
+
+                    $type = $service->department->slug;
+
+                    $s = ServiceOrder::generateServiceOrderNumber($type);
+                    $ss = ServiceOrder::generateShortServiceOrderNumber($type);
+
+                    $soShort = $type.'/'.str_pad((string) $ss, 8, '0', STR_PAD_LEFT);
+                    $soNumber = $patient->ps_number.'/'.$type.'/'.str_pad((string) $s, 8, '0', STR_PAD_LEFT);
+
+                    $token = ServiceOrder::generateToken($appointment->doctor_id, $service->id);
+
+                    $order = ServiceOrder::create([
+                        'type' => $type,
+                        'token' => $token,
+                        'so_number' => $soNumber,
+                        'so_short' => $soShort,
+                        'created_by' => $appointment->created_by,
+                        'patient_id' => $patient->id,
+                        'service_id' => $service->id,
+                        'doctor_id' => $appointment->doctor_id,
+                        'appointment_id' => $appointment->id,
+                        'priority' => $appointment->priority_mode === AppointmentPriorityMode::Priority ? 1 : 0,
+                        'is_composit' => $service->is_composit_service,
+                        'notes' => "Reserved for appointment {$appointment->appointment_number}",
+                        'notes_json' => [],
+                        'payee_type' => Patient::class,
+                        'payee_id' => $patient->id,
+                    ]);
+
+                    // 'status' is intentionally not mass-assignable (see
+                    // ServiceOrder::$fillable) — set directly, same as
+                    // CloseOldServiceOrders does when transitioning status.
+                    $order->status = 'reserved';
+                    $order->save();
+
+                    $appointment->service_order_id = $order->id;
+                    $appointment->save();
+                }
+
+                $this->info('Materialized '.count($appointments).' appointments');
+            });
+
+        $this->info('Finished materializing appointments.');
+    }
+}

--- a/app/Enum/AppointmentPriorityMode.php
+++ b/app/Enum/AppointmentPriorityMode.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Enum;
+
+use App\Models\HospitalSetting;
+
+enum AppointmentPriorityMode: string
+{
+    case Priority = 'priority';
+    case Medium = 'medium';
+    case Standard = 'standard';
+
+    public static function current(): self
+    {
+        return self::tryFrom(HospitalSetting::get('appointment_priority_mode', self::Standard->value)) ?? self::Standard;
+    }
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Priority => 'Priority (guaranteed slot, draft receivable held)',
+            self::Medium => 'Medium (reserved token, identity confidential until check-in)',
+            self::Standard => 'Standard (informational only, normal walk-in order)',
+        };
+    }
+}

--- a/app/Enum/AppointmentStatus.php
+++ b/app/Enum/AppointmentStatus.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Enum;
+
+enum AppointmentStatus: string
+{
+    case Scheduled = 'scheduled';
+    case CheckedIn = 'checked_in';
+    case NoShow = 'no_show';
+    case Cancelled = 'cancelled';
+}

--- a/app/Exports/ReceivablesReportExport.php
+++ b/app/Exports/ReceivablesReportExport.php
@@ -22,7 +22,11 @@ class ReceivablesReportExport implements FromQuery, Responsable, ShouldAutoSize,
 
     public function query()
     {
-        $query = Receaveable::query()->with(['transaction', 'patient', 'panel']);
+        $query = Receaveable::query()
+            ->with(['transaction', 'patient', 'panel'])
+            // Draft receivables are appointment holds, not real financial
+            // obligations yet — never surface them in reporting.
+            ->where('status', '!=', 'draft');
 
         if ($this->filters['from'] ?? null) {
             $query->where('receaveables.created_at', '>=', DateHelper::dayStartUtc($this->filters['from']));

--- a/app/Filament/Admin/Pages/HospitalSettings.php
+++ b/app/Filament/Admin/Pages/HospitalSettings.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Admin\Pages;
 
+use App\Enum\AppointmentPriorityMode;
 use App\Helpers\DateHelper;
 use App\Models\HospitalSetting;
 use Filament\Forms\Components\FileUpload;
@@ -42,6 +43,7 @@ class HospitalSettings extends Page implements HasForms
             'strn' => HospitalSetting::get('hospital_strn'),
             'timezone' => HospitalSetting::get('hospital_timezone', 'Asia/Karachi'),
             'abacus_auto_map_accounts' => (bool) HospitalSetting::get('abacus_auto_map_accounts', false),
+            'appointment_priority_mode' => HospitalSetting::get('appointment_priority_mode', AppointmentPriorityMode::Standard->value),
         ]);
     }
 
@@ -87,6 +89,15 @@ class HospitalSettings extends Page implements HasForms
                 Toggle::make('abacus_auto_map_accounts')
                     ->label('Auto Map Accounts (Abacus)')
                     ->helperText('When enabled, receiving a closing statement will automatically create Abacus accounting entries.'),
+                Select::make('appointment_priority_mode')
+                    ->label('Appointment Priority Handling')
+                    ->helperText('Controls how every booked appointment is treated hospital-wide once its day arrives: Priority guarantees the slot with a draft receivable and tops the queue; Medium reserves a token but hides the patient\'s identity until check-in; Standard is informational only.')
+                    ->required()
+                    ->native(false)
+                    ->options(collect(AppointmentPriorityMode::cases())
+                        ->mapWithKeys(fn (AppointmentPriorityMode $mode) => [$mode->value => $mode->label()])
+                        ->toArray())
+                    ->default(AppointmentPriorityMode::Standard->value),
             ])
             ->statePath('data');
     }
@@ -104,6 +115,7 @@ class HospitalSettings extends Page implements HasForms
         HospitalSetting::set('hospital_strn', $state['strn'] ?? null);
         HospitalSetting::set('hospital_timezone', $state['timezone'] ?? 'Asia/Karachi');
         HospitalSetting::set('abacus_auto_map_accounts', $state['abacus_auto_map_accounts'] ?? false);
+        HospitalSetting::set('appointment_priority_mode', $state['appointment_priority_mode'] ?? AppointmentPriorityMode::Standard->value);
 
         DateHelper::flushTimezoneCache();
 

--- a/app/Filament/Admin/Pages/Reports/ReceivablesReport.php
+++ b/app/Filament/Admin/Pages/Reports/ReceivablesReport.php
@@ -61,7 +61,7 @@ class ReceivablesReport extends Page implements Tables\Contracts\HasTable
                 DatePicker::make('until')->label('Until'),
                 Select::make('status')
                     ->label('Status')
-                    ->options(fn () => Receaveable::query()->distinct()->pluck('status', 'status')->toArray())
+                    ->options(fn () => Receaveable::query()->where('status', '!=', 'draft')->distinct()->pluck('status', 'status')->toArray())
                     ->placeholder('All Statuses'),
                 Select::make('panel_id')
                     ->label('Panel')
@@ -86,7 +86,10 @@ class ReceivablesReport extends Page implements Tables\Contracts\HasTable
                         'transaction:id,tr_number',
                         'patient:id,name',
                         'panel:id,name',
-                    ]);
+                    ])
+                    // Draft receivables are appointment holds, not real
+                    // financial obligations yet — never surface them here.
+                    ->where('status', '!=', 'draft');
 
                 if ($this->filters['from'] ?? null) {
                     $query->where('receaveables.created_at', '>=', DateHelper::dayStartUtc($this->filters['from']));

--- a/app/Filament/Admin/Resources/Appointments/AppointmentResource.php
+++ b/app/Filament/Admin/Resources/Appointments/AppointmentResource.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Filament\Admin\Resources\Appointments;
+
+use App\Enum\AppointmentStatus;
+use App\Filament\Admin\Resources\Appointments\Pages\ListAppointments;
+use App\Filament\Admin\Resources\Appointments\Pages\ViewAppointment;
+use App\Models\Appointment;
+use App\Services\AppointmentService;
+use BackedEnum;
+use Filament\Actions\Action;
+use Filament\Notifications\Notification;
+use Filament\Resources\Resource;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use UnitEnum;
+
+class AppointmentResource extends Resource
+{
+    protected static ?string $model = Appointment::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedCalendarDays;
+
+    protected static string|UnitEnum|null $navigationGroup = 'Reports';
+
+    protected static ?string $label = 'Appointment';
+
+    protected static ?string $recordTitleAttribute = 'appointment_number';
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->query(
+                Appointment::query()->with(['patient:id,name,ps_number', 'service:id,name', 'doctor:id,name'])
+            )
+            ->defaultSort('scheduled_at', 'desc')
+            ->columns([
+                TextColumn::make('appointment_number')
+                    ->label('Appointment #')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('patient.name')
+                    ->label('Patient')
+                    ->description(fn (Appointment $record) => $record->patient?->ps_number)
+                    ->searchable(),
+                TextColumn::make('service.name')
+                    ->label('Service')
+                    ->searchable(),
+                TextColumn::make('doctor.name')
+                    ->label('Doctor')
+                    ->placeholder('—'),
+                TextColumn::make('scheduled_at')
+                    ->label('Scheduled')
+                    ->dateTime('d M Y, h:i A')
+                    ->sortable(),
+                TextColumn::make('priority_mode')
+                    ->badge()
+                    ->color(fn ($state) => match ($state?->value ?? $state) {
+                        'priority' => 'danger',
+                        'medium' => 'warning',
+                        default => 'gray',
+                    }),
+                TextColumn::make('status')
+                    ->badge()
+                    ->color(fn ($state) => match ($state?->value ?? $state) {
+                        'checked_in' => 'success',
+                        'no_show' => 'danger',
+                        'cancelled' => 'gray',
+                        default => 'warning',
+                    }),
+            ])
+            ->filters([
+                SelectFilter::make('status')
+                    ->options(collect(AppointmentStatus::cases())
+                        ->mapWithKeys(fn (AppointmentStatus $s) => [$s->value => ucwords(str_replace('_', ' ', $s->value))])
+                        ->toArray()),
+            ])
+            ->recordActions([
+                Action::make('cancel')
+                    ->label('Cancel')
+                    ->icon(Heroicon::OutlinedXCircle)
+                    ->color('danger')
+                    ->requiresConfirmation()
+                    ->visible(fn (Appointment $record) => $record->status === AppointmentStatus::Scheduled)
+                    ->action(function (Appointment $record, AppointmentService $appointmentService): void {
+                        $appointmentService->cancel($record);
+
+                        Notification::make()
+                            ->title('Appointment cancelled')
+                            ->success()
+                            ->send();
+                    }),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListAppointments::route('/'),
+            'view' => ViewAppointment::route('/{record}'),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/Appointments/Pages/ListAppointments.php
+++ b/app/Filament/Admin/Resources/Appointments/Pages/ListAppointments.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Admin\Resources\Appointments\Pages;
+
+use App\Filament\Admin\Resources\Appointments\AppointmentResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListAppointments extends ListRecords
+{
+    protected static string $resource = AppointmentResource::class;
+}

--- a/app/Filament/Admin/Resources/Appointments/Pages/ViewAppointment.php
+++ b/app/Filament/Admin/Resources/Appointments/Pages/ViewAppointment.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Filament\Admin\Resources\Appointments\Pages;
+
+use App\Filament\Admin\Resources\Appointments\AppointmentResource;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Resources\Pages\ViewRecord;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+
+class ViewAppointment extends ViewRecord
+{
+    protected static string $resource = AppointmentResource::class;
+
+    public function infolist(Schema $schema): Schema
+    {
+        return $schema->schema([
+            Section::make('Appointment')
+                ->schema([
+                    TextEntry::make('appointment_number')->label('Appointment #')->copyable(),
+                    TextEntry::make('patient.name')->label('Patient'),
+                    TextEntry::make('patient.ps_number')->label('MR #'),
+                    TextEntry::make('service.name')->label('Service'),
+                    TextEntry::make('doctor.name')->label('Doctor')->placeholder('—'),
+                    TextEntry::make('scheduled_at')->label('Scheduled')->dateTime('d M Y, h:i A'),
+                    TextEntry::make('priority_mode')->badge(),
+                    TextEntry::make('status')->badge(),
+                    TextEntry::make('checked_in_at')->label('Checked In')->dateTime('d M Y, h:i A')->placeholder('—'),
+                    TextEntry::make('cancelled_at')->label('Cancelled')->dateTime('d M Y, h:i A')->placeholder('—'),
+                    TextEntry::make('notes')->placeholder('—')->columnSpanFull(),
+                ])
+                ->columns(2),
+            Section::make('Linked Records')
+                ->schema([
+                    TextEntry::make('serviceOrder.so_number')->label('Reserved Service Order')->placeholder('Not yet materialized'),
+                    TextEntry::make('receaveable.status')->label('Draft Receivable Status')->placeholder('None (not Priority mode)'),
+                ])
+                ->columns(2),
+        ]);
+    }
+}

--- a/app/Filament/Admin/Resources/Receaveables/ReceaveableResource.php
+++ b/app/Filament/Admin/Resources/Receaveables/ReceaveableResource.php
@@ -116,6 +116,9 @@ class ReceaveableResource extends Resource
             ->query(
                 Receaveable::query()
                     ->with(['patient:id,name,ps_number', 'panel:id,name', 'transaction:id,tr_number'])
+                    // Draft receivables are appointment holds pending check-in —
+                    // manage those from the Appointments resource, not here.
+                    ->where('status', '!=', 'draft')
             )
             ->defaultSort('created_at', 'desc')
             ->columns([

--- a/app/Filament/Admin/Widgets/Financial/FinancialKPIStats.php
+++ b/app/Filament/Admin/Widgets/Financial/FinancialKPIStats.php
@@ -56,7 +56,7 @@ class FinancialKPIStats extends StatsOverviewWidget
             ->sum('amount');
 
         $outstandingReceivables = Receaveable::query()
-            ->whereNotIn('status', ['paid', 'cancelled'])
+            ->whereNotIn('status', ['paid', 'cancelled', 'draft'])
             ->sum('amount');
 
         $pendingVouchers = ExpenseVoucher::query()

--- a/app/Filament/Admin/Widgets/Financial/ReceivablesAging.php
+++ b/app/Filament/Admin/Widgets/Financial/ReceivablesAging.php
@@ -25,7 +25,7 @@ class ReceivablesAging extends ChartWidget
     protected function getData(): array
     {
         $receivables = Receaveable::query()
-            ->whereNotIn('status', ['paid', 'cancelled'])
+            ->whereNotIn('status', ['paid', 'cancelled', 'draft'])
             ->selectRaw('DATEDIFF(NOW(), created_at) as age, amount')
             ->get();
 

--- a/app/Filament/Admin/Widgets/History/HistoryOverallStats.php
+++ b/app/Filament/Admin/Widgets/History/HistoryOverallStats.php
@@ -31,7 +31,7 @@ class HistoryOverallStats extends StatsOverviewWidget
             )->first();
 
             $evTotals = ExpenseVoucher::selectRaw('COUNT(*) as count, SUM(amount) as amount')->first();
-            $recTotals = Receaveable::selectRaw('SUM(orignal_amount) as total, SUM(CASE WHEN status NOT IN (\'paid\',\'cancelled\') THEN amount ELSE 0 END) as unpaid')->first();
+            $recTotals = Receaveable::selectRaw('SUM(CASE WHEN status != \'draft\' THEN orignal_amount ELSE 0 END) as total, SUM(CASE WHEN status NOT IN (\'paid\',\'cancelled\',\'draft\') THEN amount ELSE 0 END) as unpaid')->first();
 
             return [
                 'total_revenue' => $txTotals->revenue ?? 0,

--- a/app/Filament/Admin/Widgets/Patient/OutstandingReceivablesStats.php
+++ b/app/Filament/Admin/Widgets/Patient/OutstandingReceivablesStats.php
@@ -25,7 +25,7 @@ class OutstandingReceivablesStats extends ChartWidget
     protected function getData(): array
     {
         $data = Receaveable::query()
-            ->whereNotIn('status', ['paid', 'cancelled'])
+            ->whereNotIn('status', ['paid', 'cancelled', 'draft'])
             ->join('patients', 'receaveables.patient_id', '=', 'patients.id')
             ->selectRaw('patients.name, SUM(receaveables.amount) as total_owed')
             ->groupBy('patients.id', 'patients.name')

--- a/app/Filament/Admin/Widgets/Patient/PatientDemographicsStats.php
+++ b/app/Filament/Admin/Widgets/Patient/PatientDemographicsStats.php
@@ -44,12 +44,12 @@ class PatientDemographicsStats extends StatsOverviewWidget
             ->count();
 
         $patientsWithBalance = Receaveable::query()
-            ->whereNotIn('status', ['paid', 'cancelled'])
+            ->whereNotIn('status', ['paid', 'cancelled', 'draft'])
             ->distinct('patient_id')
             ->count('patient_id');
 
         $totalOutstanding = Receaveable::query()
-            ->whereNotIn('status', ['paid', 'cancelled'])
+            ->whereNotIn('status', ['paid', 'cancelled', 'draft'])
             ->sum('amount');
 
         $trend = Patient::query()

--- a/app/Http/Controllers/Reports/GenericReportPdfController.php
+++ b/app/Http/Controllers/Reports/GenericReportPdfController.php
@@ -100,6 +100,9 @@ class GenericReportPdfController extends Controller
         $query = Receaveable::query()
             ->where('receaveables.created_at', '>=', DateHelper::dayStartUtc($from))
             ->where('receaveables.created_at', '<=', DateHelper::dayEndUtc($until))
+            // Draft receivables are appointment holds, not real financial
+            // obligations yet — never surface them in reporting.
+            ->where('status', '!=', 'draft')
             ->with(['patient', 'panel', 'transaction']);
 
         if ($request->filled('status')) {

--- a/app/Http/Controllers/WebController.php
+++ b/app/Http/Controllers/WebController.php
@@ -2,9 +2,11 @@
 
 namespace App\Http\Controllers;
 
+use App\Enum\AppointmentStatus;
 use App\Enum\CounterStatus;
 use App\Enum\TransactionElementType;
 use App\Helpers\DateHelper;
+use App\Models\Appointment;
 use App\Models\Closing;
 use App\Models\ExpenseCategory;
 use App\Models\ExpenseVoucher;
@@ -21,9 +23,11 @@ use App\Models\ServiceRecestation;
 use App\Models\Transaction;
 use App\Models\TransactionElement;
 use App\Models\User;
+use App\Services\AppointmentService;
 use App\Services\BreachDetectionService;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
@@ -672,6 +676,16 @@ class WebController extends Controller
 
                 }
 
+                // Appointments booked for this patient, in this department, for
+                // today — surfaced so reception can check the patient in against
+                // the reserved slot/draft receivable instead of starting fresh.
+                $pageData['todaysAppointments'] = Appointment::with('service')
+                    ->where('patient_id', $pageData['selectedPatient']->id)
+                    ->where('status', AppointmentStatus::Scheduled)
+                    ->whereHas('service', fn ($q) => $q->where('service_department_id', $department->id))
+                    ->whereDate('scheduled_at', now()->toDateString())
+                    ->get();
+
                 // dd($pageData['services']->map(function($service){
                 //     if(!$service->have_service_provider || empty($service->service_provider_types)) {
                 //         dd($service);
@@ -956,6 +970,23 @@ class WebController extends Controller
                 ]);
             }
 
+            // A patient checking in for a today-scheduled appointment (Priority
+            // or Medium mode) reuses the reserved ServiceOrder materialized by
+            // app:materialize-appointments, and settles its draft receivable,
+            // instead of creating a fresh service order/receivable pair.
+            $appointment = null;
+            if (! $isRecesitation && $request->filled('appointment_id')) {
+                $request->validate([
+                    'appointment_id' => 'exists:appointments,id',
+                ]);
+
+                $appointment = Appointment::with('receaveable', 'serviceOrder')
+                    ->where('id', $request->get('appointment_id'))
+                    ->where('patient_id', $validatedData['patient_id'])
+                    ->where('status', AppointmentStatus::Scheduled)
+                    ->first();
+            }
+
             DB::beginTransaction();
 
             try {
@@ -990,7 +1021,9 @@ class WebController extends Controller
                         'patient_id' => $validatedData['patient_id'],
                         'service_id' => ! $isRecesitation ? $item['service_id'] : null,
                         'service_recestation_id' => $isRecesitation ? $item['service_id'] : null,
-                        'service_order_id' => $isRecesitation ? $request->get('service_order_id', null) : null,
+                        'service_order_id' => $isRecesitation
+                            ? $request->get('service_order_id', null)
+                            : (($appointment && $appointment->service_id == $item['service_id']) ? $appointment->service_order_id : null),
                         'doctor_id' => $item['provider_id'] ?? null,
                         'type' => $request->department_key,
                         'panel_id' => $validatedData['payment_method'] === 'PANEL' ? $validatedData['panel_company'] : null,
@@ -1004,18 +1037,49 @@ class WebController extends Controller
                 $transaction->orignal_amount = $orinalTotal;
                 $transaction->save();
 
+                $appointmentDraftReceaveable = $appointment && $appointment->receaveable && $appointment->receaveable->status === 'draft'
+                    ? $appointment->receaveable
+                    : null;
+
                 if ($validatedData['change_amount'] < 0) {
                     // Create receaveable for the remaining amount
                     $receaveableAmount = abs($validatedData['change_amount']);
 
-                    Receaveable::create([
-                        'patient_id' => $validatedData['patient_id'],
-                        'transaction_id' => $transaction->id,
-                        'amount' => $receaveableAmount,
-                        'orignal_amount' => $receaveableAmount,
-                        'status' => 'unpaid',
-                        'panel_id' => $validatedData['payment_method'] === 'PANEL' ? $validatedData['panel_company'] : null,
-                    ]);
+                    if ($appointmentDraftReceaveable) {
+                        // Convert the appointment's draft hold into the real
+                        // receivable instead of creating a duplicate one.
+                        $appointmentDraftReceaveable->update([
+                            'transaction_id' => $transaction->id,
+                            'amount' => $receaveableAmount,
+                            'orignal_amount' => $receaveableAmount,
+                            'status' => 'unpaid',
+                            'panel_id' => $validatedData['payment_method'] === 'PANEL' ? $validatedData['panel_company'] : null,
+                        ]);
+                    } else {
+                        Receaveable::create([
+                            'patient_id' => $validatedData['patient_id'],
+                            'transaction_id' => $transaction->id,
+                            'amount' => $receaveableAmount,
+                            'orignal_amount' => $receaveableAmount,
+                            'status' => 'unpaid',
+                            'panel_id' => $validatedData['payment_method'] === 'PANEL' ? $validatedData['panel_company'] : null,
+                        ]);
+                    }
+                } elseif ($appointmentDraftReceaveable) {
+                    // Paid in full (or overpaid) — settle the draft hold rather
+                    // than leaving it open.
+                    $appointmentDraftReceaveable->update(['status' => 'paid', 'amount' => 0]);
+                }
+
+                if ($appointment) {
+                    if ($appointment->serviceOrder) {
+                        $appointment->serviceOrder->status = 'open';
+                        $appointment->serviceOrder->save();
+                    }
+
+                    $appointment->status = AppointmentStatus::CheckedIn;
+                    $appointment->checked_in_at = now();
+                    $appointment->save();
                 }
 
             } catch (\Exception $e) {
@@ -1107,6 +1171,49 @@ class WebController extends Controller
             'tNumber' => $newTransaction->number,
         ]);
 
+    }
+
+    public function appointmentStore(Request $request, AppointmentService $appointmentService): RedirectResponse
+    {
+        $validatedData = $request->validate([
+            'patient_id' => 'required|exists:patients,id',
+            'service_id' => 'required|exists:services,id',
+            'doctor_id' => 'nullable|exists:users,id',
+            'scheduled_at' => 'required|date',
+            'notes' => 'nullable|string',
+        ]);
+
+        $validatedData['created_by'] = $request->user()->id;
+
+        $appointmentService->book($validatedData);
+
+        return back();
+    }
+
+    public function appointmentCancel(Request $request, Appointment $appointment, AppointmentService $appointmentService): RedirectResponse
+    {
+        if ($appointment->status !== AppointmentStatus::Scheduled && $appointment->status !== AppointmentStatus::NoShow) {
+            return back()->withErrors(['message' => 'Only scheduled appointments can be cancelled.']);
+        }
+
+        $appointmentService->cancel($appointment);
+
+        return back();
+    }
+
+    public function appointmentsCalendar(Request $request)
+    {
+        $month = $request->input('month') ? Carbon::parse($request->input('month')) : Carbon::now();
+
+        $appointments = Appointment::with(['patient:id,name,ps_number', 'service:id,name', 'doctor:id,name'])
+            ->whereBetween('scheduled_at', [$month->copy()->startOfMonth(), $month->copy()->endOfMonth()])
+            ->orderBy('scheduled_at')
+            ->get();
+
+        return Inertia::render('appointments/calendar', [
+            'appointments' => $appointments,
+            'month' => $month->format('Y-m'),
+        ]);
     }
 
     public function transactionView($tYear = null, $tMonth = null, $tDay = null, $tNumber = null)
@@ -1217,7 +1324,11 @@ class WebController extends Controller
 
         $status = $filters['status'] ?? 'unpaid';
 
-        $query = Receaveable::with(['patient', 'transaction']);
+        // Draft receivables are appointment holds pending check-in — they are
+        // resolved automatically when the patient checks in (or cleared by
+        // app:expire-no-show-appointments) and must never be directly
+        // payable from this general receivables-collection screen.
+        $query = Receaveable::with(['patient', 'transaction'])->where('status', '!=', 'draft');
 
         // Receivable statuses are stored inconsistently across the app
         // (unpaid/paid/payed/pending/cancelled, mixed case) — normalize
@@ -1498,16 +1609,17 @@ class WebController extends Controller
         $type = 'OPD';
         // Optimized: top 50 per service using window function via derived table (MySQL 8+ disallows HAVING on window alias)
         $base = ServiceOrder::query()
-            ->select(['id', 'service_id', 'patient_id', 'created_at', 'status', 'type', 'so_number'])
-            ->selectRaw('ROW_NUMBER() OVER (PARTITION BY service_id ORDER BY created_at ASC) AS rn')
+            ->select(['id', 'service_id', 'patient_id', 'created_at', 'status', 'type', 'so_number', 'priority'])
+            ->selectRaw('ROW_NUMBER() OVER (PARTITION BY service_id ORDER BY priority DESC, created_at ASC) AS rn')
             ->where('type', $type)
-            ->whereIn('status', ['open', 'in-progress', 'OPEN', 'IN-PROGRESS']);
+            ->whereIn('status', ['open', 'in-progress', 'OPEN', 'IN-PROGRESS', 'reserved']);
 
         // Filter by rn in an outer query
         $ids = DB::query()
             ->fromSub($base, 't')
             ->where('t.rn', '<=', 50)
             ->orderBy('t.service_id')
+            ->orderBy('t.priority', 'DESC')
             ->orderBy('t.created_at', 'ASC')
             ->pluck('id');
 
@@ -1515,9 +1627,11 @@ class WebController extends Controller
             ->with([
                 'patient:id,name,ps_number',
                 'service:id,name',
+                'appointment:id,priority_mode',
             ])
             ->whereIn('id', $ids)
             ->orderBy('service_id')
+            ->orderBy('priority', 'DESC')
             ->orderBy('created_at', 'ASC')
             ->get()
             ->groupBy('service_id')
@@ -1544,16 +1658,17 @@ class WebController extends Controller
         $type = 'IND';
         // Optimized: top 50 per service using window function via derived table (MySQL 8+ disallows HAVING on window alias)
         $base = ServiceOrder::query()
-            ->select(['id', 'service_id', 'patient_id', 'created_at', 'status', 'type', 'so_number'])
-            ->selectRaw('ROW_NUMBER() OVER (PARTITION BY service_id ORDER BY created_at ASC) AS rn')
+            ->select(['id', 'service_id', 'patient_id', 'created_at', 'status', 'type', 'so_number', 'priority'])
+            ->selectRaw('ROW_NUMBER() OVER (PARTITION BY service_id ORDER BY priority DESC, created_at ASC) AS rn')
             ->where('type', $type)
-            ->whereIn('status', ['open', 'in-progress', 'OPEN', 'IN-PROGRESS']);
+            ->whereIn('status', ['open', 'in-progress', 'OPEN', 'IN-PROGRESS', 'reserved']);
 
         // Filter by rn in an outer query
         $ids = DB::query()
             ->fromSub($base, 't')
             ->where('t.rn', '<=', 15)
             ->orderBy('t.service_id')
+            ->orderBy('t.priority', 'DESC')
             ->orderBy('t.created_at', 'ASC')
             ->pluck('id');
 
@@ -1561,9 +1676,11 @@ class WebController extends Controller
             ->with([
                 'patient:id,name,ps_number',
                 'service:id,name',
+                'appointment:id,priority_mode',
             ])
             ->whereIn('id', $ids)
             ->orderBy('service_id')
+            ->orderBy('priority', 'DESC')
             ->orderBy('created_at', 'ASC')
             ->get()
             ->groupBy('service_id')
@@ -1590,16 +1707,17 @@ class WebController extends Controller
         $type = 'EMG';
         // Optimized: top 50 per service using window function via derived table (MySQL 8+ disallows HAVING on window alias)
         $base = ServiceOrder::query()
-            ->select(['id', 'service_id', 'patient_id', 'created_at', 'status', 'type', 'so_number'])
-            ->selectRaw('ROW_NUMBER() OVER (PARTITION BY service_id ORDER BY created_at ASC) AS rn')
+            ->select(['id', 'service_id', 'patient_id', 'created_at', 'status', 'type', 'so_number', 'priority'])
+            ->selectRaw('ROW_NUMBER() OVER (PARTITION BY service_id ORDER BY priority DESC, created_at ASC) AS rn')
             ->where('type', $type)
-            ->whereIn('status', ['open', 'in-progress', 'OPEN', 'IN-PROGRESS']);
+            ->whereIn('status', ['open', 'in-progress', 'OPEN', 'IN-PROGRESS', 'reserved']);
 
         // Filter by rn in an outer query
         $ids = DB::query()
             ->fromSub($base, 't')
             ->where('t.rn', '<=', 50)
             ->orderBy('t.service_id')
+            ->orderBy('t.priority', 'DESC')
             ->orderBy('t.created_at', 'ASC')
             ->pluck('id');
 
@@ -1607,9 +1725,11 @@ class WebController extends Controller
             ->with([
                 'patient:id,name,ps_number',
                 'service:id,name',
+                'appointment:id,priority_mode',
             ])
             ->whereIn('id', $ids)
             ->orderBy('service_id')
+            ->orderBy('priority', 'DESC')
             ->orderBy('created_at', 'ASC')
             ->get()
             ->groupBy('service_id')
@@ -1635,16 +1755,17 @@ class WebController extends Controller
         $type = 'DNT';
         // Optimized: top 50 per service using window function via derived table (MySQL 8+ disallows HAVING on window alias)
         $base = ServiceOrder::query()
-            ->select(['id', 'service_id', 'patient_id', 'created_at', 'status', 'type', 'so_number'])
-            ->selectRaw('ROW_NUMBER() OVER (PARTITION BY service_id ORDER BY created_at ASC) AS rn')
+            ->select(['id', 'service_id', 'patient_id', 'created_at', 'status', 'type', 'so_number', 'priority'])
+            ->selectRaw('ROW_NUMBER() OVER (PARTITION BY service_id ORDER BY priority DESC, created_at ASC) AS rn')
             ->where('type', $type)
-            ->whereIn('status', ['open', 'in-progress', 'OPEN', 'IN-PROGRESS']);
+            ->whereIn('status', ['open', 'in-progress', 'OPEN', 'IN-PROGRESS', 'reserved']);
 
         // Filter by rn in an outer query
         $ids = DB::query()
             ->fromSub($base, 't')
             ->where('t.rn', '<=', 50)
             ->orderBy('t.service_id')
+            ->orderBy('t.priority', 'DESC')
             ->orderBy('t.created_at', 'ASC')
             ->pluck('id');
 
@@ -1652,9 +1773,11 @@ class WebController extends Controller
             ->with([
                 'patient:id,name,ps_number',
                 'service:id,name',
+                'appointment:id,priority_mode',
             ])
             ->whereIn('id', $ids)
             ->orderBy('service_id')
+            ->orderBy('priority', 'DESC')
             ->orderBy('created_at', 'ASC')
             ->get()
             ->groupBy('service_id')
@@ -1680,16 +1803,17 @@ class WebController extends Controller
         $type = 'PTH';
         // Optimized: top 50 per service using window function via derived table (MySQL 8+ disallows HAVING on window alias)
         $base = ServiceOrder::query()
-            ->select(['id', 'service_id', 'patient_id', 'created_at', 'status', 'type', 'so_number'])
-            ->selectRaw('ROW_NUMBER() OVER (PARTITION BY service_id ORDER BY created_at ASC) AS rn')
+            ->select(['id', 'service_id', 'patient_id', 'created_at', 'status', 'type', 'so_number', 'priority'])
+            ->selectRaw('ROW_NUMBER() OVER (PARTITION BY service_id ORDER BY priority DESC, created_at ASC) AS rn')
             ->where('type', $type)
-            ->whereIn('status', ['open', 'in-progress', 'OPEN', 'IN-PROGRESS']);
+            ->whereIn('status', ['open', 'in-progress', 'OPEN', 'IN-PROGRESS', 'reserved']);
 
         // Filter by rn in an outer query
         $ids = DB::query()
             ->fromSub($base, 't')
             ->where('t.rn', '<=', 50)
             ->orderBy('t.service_id')
+            ->orderBy('t.priority', 'DESC')
             ->orderBy('t.created_at', 'ASC')
             ->pluck('id');
 
@@ -1697,9 +1821,11 @@ class WebController extends Controller
             ->with([
                 'patient:id,name,ps_number',
                 'service:id,name',
+                'appointment:id,priority_mode',
             ])
             ->whereIn('id', $ids)
             ->orderBy('service_id')
+            ->orderBy('priority', 'DESC')
             ->orderBy('created_at', 'ASC')
             ->get()
             ->groupBy('service_id')
@@ -1725,16 +1851,17 @@ class WebController extends Controller
         $type = 'ULT';
         // Optimized: top 50 per service using window function via derived table (MySQL 8+ disallows HAVING on window alias)
         $base = ServiceOrder::query()
-            ->select(['id', 'service_id', 'patient_id', 'created_at', 'status', 'type', 'so_number'])
-            ->selectRaw('ROW_NUMBER() OVER (PARTITION BY service_id ORDER BY created_at ASC) AS rn')
+            ->select(['id', 'service_id', 'patient_id', 'created_at', 'status', 'type', 'so_number', 'priority'])
+            ->selectRaw('ROW_NUMBER() OVER (PARTITION BY service_id ORDER BY priority DESC, created_at ASC) AS rn')
             ->where('type', $type)
-            ->whereIn('status', ['open', 'in-progress', 'OPEN', 'IN-PROGRESS']);
+            ->whereIn('status', ['open', 'in-progress', 'OPEN', 'IN-PROGRESS', 'reserved']);
 
         // Filter by rn in an outer query
         $ids = DB::query()
             ->fromSub($base, 't')
             ->where('t.rn', '<=', 50)
             ->orderBy('t.service_id')
+            ->orderBy('t.priority', 'DESC')
             ->orderBy('t.created_at', 'ASC')
             ->pluck('id');
 
@@ -1742,9 +1869,11 @@ class WebController extends Controller
             ->with([
                 'patient:id,name,ps_number',
                 'service:id,name',
+                'appointment:id,priority_mode',
             ])
             ->whereIn('id', $ids)
             ->orderBy('service_id')
+            ->orderBy('priority', 'DESC')
             ->orderBy('created_at', 'ASC')
             ->get()
             ->groupBy('service_id')
@@ -1772,16 +1901,17 @@ class WebController extends Controller
         $types = ['XRAY', 'RAD'];
         // Optimized: top 50 per service using window function via derived table (MySQL 8+ disallows HAVING on window alias)
         $base = ServiceOrder::query()
-            ->select(['id', 'service_id', 'patient_id', 'created_at', 'status', 'type', 'so_number'])
-            ->selectRaw('ROW_NUMBER() OVER (PARTITION BY service_id ORDER BY created_at ASC) AS rn')
+            ->select(['id', 'service_id', 'patient_id', 'created_at', 'status', 'type', 'so_number', 'priority'])
+            ->selectRaw('ROW_NUMBER() OVER (PARTITION BY service_id ORDER BY priority DESC, created_at ASC) AS rn')
             ->whereIn('type', $types)
-            ->whereIn('status', ['open', 'in-progress', 'OPEN', 'IN-PROGRESS']);
+            ->whereIn('status', ['open', 'in-progress', 'OPEN', 'IN-PROGRESS', 'reserved']);
 
         // Filter by rn in an outer query
         $ids = DB::query()
             ->fromSub($base, 't')
             ->where('t.rn', '<=', 50)
             ->orderBy('t.service_id')
+            ->orderBy('t.priority', 'DESC')
             ->orderBy('t.created_at', 'ASC')
             ->pluck('id');
 
@@ -1789,9 +1919,11 @@ class WebController extends Controller
             ->with([
                 'patient:id,name,ps_number',
                 'service:id,name',
+                'appointment:id,priority_mode',
             ])
             ->whereIn('id', $ids)
             ->orderBy('service_id')
+            ->orderBy('priority', 'DESC')
             ->orderBy('created_at', 'ASC')
             ->get()
             ->groupBy('service_id')

--- a/app/Models/Appointment.php
+++ b/app/Models/Appointment.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Models;
+
+use App\Enum\AppointmentPriorityMode;
+use App\Enum\AppointmentStatus;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+
+class Appointment extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $fillable = [
+        'appointment_number',
+        'patient_id',
+        'service_id',
+        'doctor_id',
+        'scheduled_at',
+        'priority_mode',
+        'status',
+        'service_order_id',
+        'receaveable_id',
+        'checked_in_at',
+        'cancelled_at',
+        'notes',
+        'created_by',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'priority_mode' => AppointmentPriorityMode::class,
+            'status' => AppointmentStatus::class,
+            'scheduled_at' => 'datetime',
+            'checked_in_at' => 'datetime',
+            'cancelled_at' => 'datetime',
+        ];
+    }
+
+    public function patient(): BelongsTo
+    {
+        return $this->belongsTo(Patient::class);
+    }
+
+    public function service(): BelongsTo
+    {
+        return $this->belongsTo(Service::class);
+    }
+
+    public function doctor(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'doctor_id');
+    }
+
+    public function serviceOrder(): BelongsTo
+    {
+        return $this->belongsTo(ServiceOrder::class);
+    }
+
+    public function receaveable(): BelongsTo
+    {
+        return $this->belongsTo(Receaveable::class);
+    }
+
+    public function creator(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    public static function generateAppointmentNumber(): string
+    {
+        return DB::transaction(function () {
+            $now = Carbon::now();
+            $year = $now->format('Y');
+            $month = $now->format('m');
+            $prefix = "APT/{$year}/{$month}/";
+
+            $existingNumbers = self::withTrashed()
+                ->where('appointment_number', 'like', "{$prefix}%")
+                ->lockForUpdate()
+                ->pluck('appointment_number');
+
+            $maxSequence = 0;
+            foreach ($existingNumbers as $appointmentNumber) {
+                $parts = explode('/', (string) $appointmentNumber);
+                $sequence = (int) ($parts[3] ?? 0);
+                if ($sequence > $maxSequence) {
+                    $maxSequence = $sequence;
+                }
+            }
+
+            $nextSequence = $maxSequence + 1;
+            $count = str_pad((string) $nextSequence, 4, '0', STR_PAD_LEFT);
+
+            return "{$prefix}{$count}";
+        });
+    }
+}

--- a/app/Models/Receaveable.php
+++ b/app/Models/Receaveable.php
@@ -25,6 +25,7 @@ class Receaveable extends Model
         'patient_id',
         'panel_id',
         'transaction_id',
+        'appointment_id',
         'amount',
         'orignal_amount',
         'due_date',
@@ -34,6 +35,16 @@ class Receaveable extends Model
     public function patient()
     {
         return $this->belongsTo(Patient::class);
+    }
+
+    /**
+     * The appointment that reserved this receivable as a draft hold. Only
+     * set for Priority-mode appointments — draft receivables have no
+     * transaction yet, so they link back here instead of transaction_id.
+     */
+    public function appointment()
+    {
+        return $this->belongsTo(Appointment::class);
     }
 
     public function transaction()

--- a/app/Models/ServiceOrder.php
+++ b/app/Models/ServiceOrder.php
@@ -40,6 +40,8 @@ class ServiceOrder extends Model
         'service_id',
         'service_recestation_id',
         'doctor_id',
+        'appointment_id',
+        'priority',
         'is_composit',
         'notes',
         'notes_json',
@@ -171,6 +173,16 @@ class ServiceOrder extends Model
     public function doctor(): BelongsTo
     {
         return $this->belongsTo(User::class, 'doctor_id');
+    }
+
+    /**
+     * The appointment that materialized this service order (Priority/Medium
+     * modes only — reserved ahead of the patient's arrival on their
+     * scheduled day). Absent for ordinary walk-in service orders.
+     */
+    public function appointment(): BelongsTo
+    {
+        return $this->belongsTo(Appointment::class);
     }
 
     /**

--- a/app/Observers/AppointmentObserver.php
+++ b/app/Observers/AppointmentObserver.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Observers;
+
+use App\Enum\AppointmentPriorityMode;
+use App\Models\Appointment;
+
+class AppointmentObserver
+{
+    public function creating(Appointment $appointment): void
+    {
+        if (empty($appointment->appointment_number)) {
+            $appointment->appointment_number = Appointment::generateAppointmentNumber();
+        }
+
+        if (empty($appointment->priority_mode)) {
+            $appointment->priority_mode = AppointmentPriorityMode::current();
+        }
+    }
+}

--- a/app/Observers/TransactionElementObserver.php
+++ b/app/Observers/TransactionElementObserver.php
@@ -17,6 +17,13 @@ class TransactionElementObserver
             return;
         }
 
+        // An appointment check-in (or recesitation) already carries a
+        // pre-existing service_order_id assigned by the controller — reuse
+        // it rather than spawning a duplicate order.
+        if ($transactionElement->service_order_id) {
+            return;
+        }
+
         // A receivable-payment transaction reuses an existing service order;
         // it must NOT spawn a new one. The parent transaction's receaveable_id
         // marks the transaction as a payment against a prior receivable.

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\Helpers\UserTimezone;
+use App\Models\Appointment;
 use App\Models\Asset;
 use App\Models\Closing;
 use App\Models\ExpenseVoucher;
@@ -14,6 +15,7 @@ use App\Models\Task;
 use App\Models\Transaction;
 use App\Models\TransactionElement;
 use App\Models\User;
+use App\Observers\AppointmentObserver;
 use App\Observers\AssetObserver;
 use App\Observers\ClosingObserver;
 use App\Observers\ExpenseVoucherObserver;
@@ -67,6 +69,7 @@ class AppServiceProvider extends ServiceProvider
         PurchaseOrder::observe(PurchaseOrderObserver::class);
         Asset::observe(AssetObserver::class);
         Task::observe(TaskObserver::class);
+        Appointment::observe(AppointmentObserver::class);
 
         Gate::define('viewPulse', function (User $user) {
             return $user->adminProfiles()->count() > 0;

--- a/app/Services/AppointmentService.php
+++ b/app/Services/AppointmentService.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Services;
+
+use App\Enum\AppointmentPriorityMode;
+use App\Enum\AppointmentStatus;
+use App\Models\Appointment;
+use App\Models\Receaveable;
+use App\Models\Service;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+
+class AppointmentService
+{
+    /**
+     * Book a future appointment. The current global priority mode is
+     * snapshotted onto the appointment so a later change to the hospital-wide
+     * setting never retroactively changes how an already-booked appointment
+     * behaves.
+     *
+     * No ServiceOrder is created here for any mode — the live queue has no
+     * date scoping, so materializing immediately would make a visit booked
+     * weeks out appear in *today's* queue. That happens on the appointment's
+     * actual day instead, via the app:materialize-appointments command.
+     *
+     * @param  array{patient_id:int,service_id:int,doctor_id?:int|null,scheduled_at:string,notes?:string|null,created_by:int}  $data
+     */
+    public function book(array $data): Appointment
+    {
+        return DB::transaction(function () use ($data) {
+            $priorityMode = AppointmentPriorityMode::current();
+
+            $appointment = Appointment::create([
+                'patient_id' => $data['patient_id'],
+                'service_id' => $data['service_id'],
+                'doctor_id' => $data['doctor_id'] ?? null,
+                'scheduled_at' => $data['scheduled_at'],
+                'priority_mode' => $priorityMode,
+                'status' => AppointmentStatus::Scheduled,
+                'notes' => $data['notes'] ?? null,
+                'created_by' => $data['created_by'],
+            ]);
+
+            if ($priorityMode === AppointmentPriorityMode::Priority) {
+                $service = Service::findOrFail($data['service_id']);
+
+                $receaveable = Receaveable::create([
+                    'patient_id' => $data['patient_id'],
+                    'appointment_id' => $appointment->id,
+                    'amount' => $service->charges,
+                    'orignal_amount' => $service->charges,
+                    'status' => 'draft',
+                    'due_date' => Carbon::parse($data['scheduled_at'])->toDateString(),
+                ]);
+
+                $appointment->receaveable_id = $receaveable->id;
+                $appointment->save();
+            }
+
+            return $appointment;
+        });
+    }
+
+    /**
+     * Cancel a scheduled appointment before its day arrives (or before
+     * check-in). Mirrors the cleanup ExpireNoShowAppointments performs for
+     * unattended appointments: the draft receivable is cancelled (never
+     * deleted, to preserve the audit trail) and any already-materialized
+     * reserved service order is closed so it drops out of the live queue.
+     */
+    public function cancel(Appointment $appointment): Appointment
+    {
+        return DB::transaction(function () use ($appointment) {
+            $appointment->loadMissing(['receaveable', 'serviceOrder']);
+
+            if ($appointment->receaveable && $appointment->receaveable->status === 'draft') {
+                $appointment->receaveable->status = 'cancelled';
+                $appointment->receaveable->save();
+            }
+
+            if ($appointment->serviceOrder && empty($appointment->serviceOrder->closed_at)) {
+                $appointment->serviceOrder->closed_at = now();
+                $appointment->serviceOrder->status = 'CLOSED';
+                $appointment->serviceOrder->notes = 'Automatically closed by system: appointment was cancelled.';
+                $appointment->serviceOrder->save();
+            }
+
+            $appointment->status = AppointmentStatus::Cancelled;
+            $appointment->cancelled_at = now();
+            $appointment->save();
+
+            return $appointment;
+        });
+    }
+}

--- a/database/factories/AppointmentFactory.php
+++ b/database/factories/AppointmentFactory.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enum\AppointmentPriorityMode;
+use App\Enum\AppointmentStatus;
+use App\Models\Patient;
+use App\Models\Service;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class AppointmentFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'patient_id' => Patient::factory(),
+            'service_id' => Service::factory(),
+            'doctor_id' => null,
+            'scheduled_at' => now()->addDay(),
+            'priority_mode' => AppointmentPriorityMode::Standard,
+            'status' => AppointmentStatus::Scheduled,
+            'created_by' => User::factory(),
+        ];
+    }
+
+    public function priority(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'priority_mode' => AppointmentPriorityMode::Priority,
+        ]);
+    }
+
+    public function medium(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'priority_mode' => AppointmentPriorityMode::Medium,
+        ]);
+    }
+
+    public function scheduledToday(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'scheduled_at' => now(),
+        ]);
+    }
+
+    public function noShow(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => AppointmentStatus::NoShow,
+        ]);
+    }
+}

--- a/database/migrations/2026_08_03_090000_create_appointments_table.php
+++ b/database/migrations/2026_08_03_090000_create_appointments_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('appointments', function (Blueprint $table) {
+            $table->id();
+            $table->string('appointment_number')->unique();
+            $table->foreignId('patient_id')->constrained('patients')->onDelete('cascade');
+            $table->foreignId('service_id')->constrained('services')->onDelete('cascade');
+            $table->foreignId('doctor_id')->nullable()->constrained('users')->onDelete('set null');
+            $table->dateTime('scheduled_at');
+            $table->string('priority_mode');
+            $table->string('status')->default('scheduled');
+            $table->foreignId('service_order_id')->nullable()->constrained('service_orders')->onDelete('set null');
+            $table->foreignId('receaveable_id')->nullable()->constrained('receaveables')->onDelete('set null');
+            $table->dateTime('checked_in_at')->nullable();
+            $table->dateTime('cancelled_at')->nullable();
+            $table->text('notes')->nullable();
+            $table->foreignId('created_by')->constrained('users')->onDelete('cascade');
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->index(['scheduled_at', 'status']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('appointments');
+    }
+};

--- a/database/migrations/2026_08_03_090100_add_appointment_id_to_receaveables_table.php
+++ b/database/migrations/2026_08_03_090100_add_appointment_id_to_receaveables_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('receaveables', function (Blueprint $table) {
+            // Draft receivables created when a Priority-mode appointment is booked
+            // have no transaction yet, so they link back through the appointment
+            // instead of transaction_id.
+            $table->foreignId('appointment_id')->nullable()->after('panel_id')->constrained('appointments')->onDelete('set null');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('receaveables', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('appointment_id');
+        });
+    }
+};

--- a/database/migrations/2026_08_03_090200_add_appointment_columns_to_service_orders_table.php
+++ b/database/migrations/2026_08_03_090200_add_appointment_columns_to_service_orders_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('service_orders', function (Blueprint $table) {
+            $table->foreignId('appointment_id')->nullable()->after('doctor_id')->constrained('appointments')->onDelete('set null');
+            // Pins Priority-mode appointment reservations at the top of the queue
+            // ordering (ORDER BY priority DESC, created_at ASC) without touching
+            // created_at / the audit trail.
+            $table->tinyInteger('priority')->default(0)->after('status');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('service_orders', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('appointment_id');
+            $table->dropColumn('priority');
+        });
+    }
+};

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -10,6 +10,7 @@ import {
     SidebarMenuItem,
 } from '@/components/ui/sidebar';
 import {
+    appointmentsCalendar,
     counter,
     counterExpenseVouchersList,
     dntDashboard,
@@ -40,6 +41,7 @@ import { Link, usePage } from '@inertiajs/react';
 import {
     BookAIcon,
     BriefcaseMedical,
+    CalendarDays,
     ChartLine,
     Cog,
     FlaskConical,
@@ -447,6 +449,21 @@ export function AppSidebar() {
                                 <Link href={receaveables().url} prefetch>
                                     <LucideWaypoints />
                                     <span>Receaveables</span>
+                                </Link>
+                            </SidebarMenuButton>
+                        </SidebarMenuItem>
+                        <SidebarMenuItem>
+                            <SidebarMenuButton
+                                asChild
+                                isActive={routeName === 'appointments-calendar'}
+                                tooltip={{ children: 'Appointments' }}
+                            >
+                                <Link
+                                    href={appointmentsCalendar().url}
+                                    prefetch
+                                >
+                                    <CalendarDays />
+                                    <span>Appointments</span>
                                 </Link>
                             </SidebarMenuButton>
                         </SidebarMenuItem>

--- a/resources/js/pages/appointments/calendar.tsx
+++ b/resources/js/pages/appointments/calendar.tsx
@@ -1,0 +1,283 @@
+import { Button } from '@/components/ui/button';
+import AppLayout from '@/layouts/app-layout';
+import { appointmentCancel, appointmentsCalendar, home } from '@/routes';
+import { type BreadcrumbItem } from '@/types';
+import { Head, router, usePage } from '@inertiajs/react';
+import { clsx } from 'clsx';
+import { useMemo, useState } from 'react';
+import { toast } from 'sonner';
+
+type Appointment = {
+    id: number;
+    appointment_number: string;
+    patient?: { name: string; ps_number: string };
+    service?: { name: string };
+    doctor?: { name: string };
+    scheduled_at: string;
+    priority_mode: 'priority' | 'medium' | 'standard';
+    status: 'scheduled' | 'checked_in' | 'no_show' | 'cancelled';
+};
+
+type AppointmentsCalendarProps = {
+    appointments: Appointment[];
+    month: string;
+    [key: string]: unknown;
+};
+
+const priorityBadge: Record<string, string> = {
+    priority: 'bg-red-100 text-red-700',
+    medium: 'bg-amber-100 text-amber-700',
+    standard: 'bg-slate-100 text-slate-700',
+};
+
+const statusBadge: Record<string, string> = {
+    scheduled: 'bg-blue-100 text-blue-700',
+    checked_in: 'bg-emerald-100 text-emerald-700',
+    no_show: 'bg-red-100 text-red-700',
+    cancelled: 'bg-slate-200 text-slate-600',
+};
+
+function displayName(appointment: Appointment): string {
+    if (
+        appointment.status === 'scheduled' &&
+        appointment.priority_mode === 'medium'
+    ) {
+        return 'Reserved Appointment';
+    }
+    return appointment.patient?.name ?? 'Unknown Patient';
+}
+
+export default function AppointmentsCalendar() {
+    const { appointments, month } = usePage<AppointmentsCalendarProps>().props;
+
+    const breadcrumbs: BreadcrumbItem[] = [
+        { title: 'Dashboard', href: home().url },
+        { title: 'Appointments', href: appointmentsCalendar().url },
+    ];
+
+    const [selectedDate, setSelectedDate] = useState<string | null>(null);
+
+    const byDate = useMemo(() => {
+        const map: Record<string, Appointment[]> = {};
+        for (const appointment of appointments) {
+            const date = appointment.scheduled_at.slice(0, 10);
+            if (!map[date]) {
+                map[date] = [];
+            }
+            map[date].push(appointment);
+        }
+        return map;
+    }, [appointments]);
+
+    const [year, monthNum] = month.split('-').map(Number);
+    const firstOfMonth = new Date(year, monthNum - 1, 1);
+    const daysInMonth = new Date(year, monthNum, 0).getDate();
+    const startWeekday = firstOfMonth.getDay();
+
+    const cells: (string | null)[] = [
+        ...Array(startWeekday).fill(null),
+        ...Array.from({ length: daysInMonth }, (_, i) => {
+            const day = String(i + 1).padStart(2, '0');
+            const m = String(monthNum).padStart(2, '0');
+            return `${year}-${m}-${day}`;
+        }),
+    ];
+
+    const goToMonth = (delta: number) => {
+        const next = new Date(year, monthNum - 1 + delta, 1);
+        const nextMonth = `${next.getFullYear()}-${String(next.getMonth() + 1).padStart(2, '0')}`;
+        router.get(
+            appointmentsCalendar().url,
+            { month: nextMonth },
+            { preserveState: true },
+        );
+    };
+
+    const cancelAppointment = (appointment: Appointment) => {
+        router.post(
+            appointmentCancel(appointment.id).url,
+            {},
+            {
+                preserveScroll: true,
+                onSuccess: () => toast.success('Appointment cancelled.'),
+                onError: () => toast.error('Could not cancel appointment.'),
+            },
+        );
+    };
+
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <Head title="Appointments" />
+            <div className="flex h-full flex-1 flex-col gap-4 overflow-x-auto rounded-xl bg-[#06df72] p-1 dark:bg-[#262626]">
+                <div className="flex flex-1 flex-col gap-4 overflow-x-auto rounded-xl bg-white p-4 text-gray-800 dark:bg-neutral-950 dark:text-white">
+                    <div className="flex items-center justify-between">
+                        <h3 className="text-2xl font-bold">
+                            {firstOfMonth.toLocaleString('default', {
+                                month: 'long',
+                                year: 'numeric',
+                            })}
+                        </h3>
+                        <div className="flex gap-2">
+                            <Button
+                                variant="outline"
+                                onClick={() => goToMonth(-1)}
+                            >
+                                Previous
+                            </Button>
+                            <Button
+                                variant="outline"
+                                onClick={() => goToMonth(1)}
+                            >
+                                Next
+                            </Button>
+                        </div>
+                    </div>
+
+                    <div className="grid grid-cols-7 gap-1 text-center text-xs font-semibold text-slate-500">
+                        {['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].map(
+                            (d) => (
+                                <div key={d}>{d}</div>
+                            ),
+                        )}
+                    </div>
+
+                    <div className="grid grid-cols-7 gap-1">
+                        {cells.map((date, idx) => (
+                            <div
+                                key={idx}
+                                className={clsx(
+                                    'min-h-24 rounded-lg border p-1 text-xs dark:border-neutral-800',
+                                    !date &&
+                                        'border-transparent bg-transparent',
+                                )}
+                            >
+                                {date && (
+                                    <>
+                                        <div className="mb-1 font-semibold text-slate-500">
+                                            {Number(date.slice(8, 10))}
+                                        </div>
+                                        <div className="flex flex-col gap-1">
+                                            {(byDate[date] ?? [])
+                                                .slice(0, 3)
+                                                .map((appointment) => (
+                                                    <button
+                                                        key={appointment.id}
+                                                        onClick={() =>
+                                                            setSelectedDate(
+                                                                date,
+                                                            )
+                                                        }
+                                                        className={clsx(
+                                                            'truncate rounded px-1 py-0.5 text-left',
+                                                            priorityBadge[
+                                                                appointment
+                                                                    .priority_mode
+                                                            ],
+                                                        )}
+                                                    >
+                                                        {displayName(
+                                                            appointment,
+                                                        )}
+                                                    </button>
+                                                ))}
+                                            {(byDate[date]?.length ?? 0) >
+                                                3 && (
+                                                <button
+                                                    onClick={() =>
+                                                        setSelectedDate(date)
+                                                    }
+                                                    className="text-left text-slate-400 hover:underline"
+                                                >
+                                                    +
+                                                    {(byDate[date]?.length ??
+                                                        0) - 3}{' '}
+                                                    more
+                                                </button>
+                                            )}
+                                        </div>
+                                    </>
+                                )}
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            </div>
+
+            {selectedDate && (
+                <div
+                    className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+                    onClick={() => setSelectedDate(null)}
+                >
+                    <div
+                        className="max-h-[80vh] w-full max-w-lg overflow-y-auto rounded-xl bg-white p-6 dark:bg-neutral-900"
+                        onClick={(e) => e.stopPropagation()}
+                    >
+                        <div className="mb-4 flex items-center justify-between">
+                            <h4 className="text-lg font-semibold">
+                                Appointments on {selectedDate}
+                            </h4>
+                            <button
+                                onClick={() => setSelectedDate(null)}
+                                className="text-slate-400 hover:text-slate-600"
+                            >
+                                ✕
+                            </button>
+                        </div>
+                        <div className="flex flex-col gap-3">
+                            {(byDate[selectedDate] ?? []).map((appointment) => (
+                                <div
+                                    key={appointment.id}
+                                    className="rounded-lg border p-3 dark:border-neutral-800"
+                                >
+                                    <div className="mb-1 flex items-center gap-2">
+                                        <span
+                                            className={clsx(
+                                                'rounded px-2 py-0.5 text-xs font-semibold',
+                                                priorityBadge[
+                                                    appointment.priority_mode
+                                                ],
+                                            )}
+                                        >
+                                            {appointment.priority_mode}
+                                        </span>
+                                        <span
+                                            className={clsx(
+                                                'rounded px-2 py-0.5 text-xs font-semibold',
+                                                statusBadge[appointment.status],
+                                            )}
+                                        >
+                                            {appointment.status}
+                                        </span>
+                                    </div>
+                                    <div className="font-semibold">
+                                        {displayName(appointment)}
+                                    </div>
+                                    <div className="text-sm text-slate-500">
+                                        {appointment.service?.name}
+                                        {appointment.doctor?.name
+                                            ? ` — ${appointment.doctor.name}`
+                                            : ''}
+                                    </div>
+                                    <div className="text-xs text-slate-400">
+                                        {appointment.appointment_number}
+                                    </div>
+                                    {appointment.status === 'scheduled' && (
+                                        <Button
+                                            variant="outline"
+                                            className="mt-2 text-red-600"
+                                            onClick={() =>
+                                                cancelAppointment(appointment)
+                                            }
+                                        >
+                                            Cancel Appointment
+                                        </Button>
+                                    )}
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+                </div>
+            )}
+        </AppLayout>
+    );
+}

--- a/resources/js/pages/counter/income.tsx
+++ b/resources/js/pages/counter/income.tsx
@@ -28,6 +28,7 @@ import PatientHistorySideBar from '@/elements/patient/transactions-history-card'
 import AppLayout from '@/layouts/app-layout';
 import {
     apiPatientsStore,
+    appointmentStore,
     counter,
     counterSelectDepartment,
     counterSelectDepartmentService,
@@ -64,6 +65,7 @@ export default function CounterIncome() {
         recesitation,
         existingServiceOrders,
         panelCompanies,
+        todaysAppointments,
     } = usePage().props;
 
     const step = !selectedPatient ? 1 : !departmentKey ? 2 : 3;
@@ -198,6 +200,7 @@ export default function CounterIncome() {
                                 services={services}
                                 providers={providers}
                                 panelCompanies={panelCompanies ?? []}
+                                todaysAppointments={todaysAppointments ?? []}
                             />
                         )}
                     </BulletsWrapper>
@@ -217,6 +220,7 @@ function CollectPayment({
     services,
     providers,
     panelCompanies,
+    todaysAppointments,
 }: any) {
     const [selectedServices, setSelectedServices] = useState<string[]>([]);
     const [mriNumber, setMriNumber] = useState<string>('');
@@ -227,6 +231,9 @@ function CollectPayment({
     const [serviceProviders, setServiceProviders] = useState<any>({});
     const [selectedServiceOrder, setSelectedServiceOrder] = useState<string>();
     const [processing, setProcessing] = useState<boolean>(false);
+    const [checkInAppointmentId, setCheckInAppointmentId] = useState<
+        string | null
+    >(null);
 
     const [formData, setFormData] = useState<any>({
         total: 0,
@@ -278,6 +285,7 @@ function CollectPayment({
                 patient_number: patient.number,
                 department_key: departmentKey,
                 service_order_id: selectedServiceOrder || null,
+                appointment_id: checkInAppointmentId || null,
                 income_or_expense: 'INCOME',
                 items: formData.items.map((item: any) => ({
                     service_id: item.serviceId,
@@ -478,6 +486,32 @@ function CollectPayment({
                             className="col-span-3 w-full"
                         />
                     </div>
+
+                    {!recesitation && todaysAppointments?.length > 0 && (
+                        <AppointmentCheckInBanner
+                            appointments={todaysAppointments}
+                            checkInAppointmentId={checkInAppointmentId}
+                            onSelect={(appointment: any) => {
+                                setCheckInAppointmentId(
+                                    appointment ? String(appointment.id) : null,
+                                );
+                                if (appointment) {
+                                    setSelectedServices([
+                                        String(appointment.service_id),
+                                    ]);
+                                }
+                            }}
+                        />
+                    )}
+
+                    {!recesitation && (
+                        <BookAppointmentAccordion
+                            patient={patient}
+                            services={services}
+                            providers={providers}
+                        />
+                    )}
+
                     <div className="mb-2 rounded-xl border p-4 dark:border-neutral-950">
                         {recesitation && (
                             <div className="mb-2 grid gap-2">
@@ -948,6 +982,196 @@ function CollectPayment({
                     </div>
                 </div>
             </div>
+        </div>
+    );
+}
+
+function AppointmentCheckInBanner({
+    appointments,
+    checkInAppointmentId,
+    onSelect,
+}: any) {
+    return (
+        <div className="mb-2 rounded-xl border border-amber-300 bg-amber-50 p-4 dark:border-amber-900 dark:bg-amber-950">
+            <h4 className="mb-2 text-sm font-semibold text-amber-800 dark:text-amber-200">
+                This patient has an appointment today
+            </h4>
+            <div className="flex flex-col gap-2">
+                {appointments.map((appointment: any) => {
+                    const isSelected =
+                        checkInAppointmentId === String(appointment.id);
+                    return (
+                        <label
+                            key={appointment.id}
+                            className={clsx(
+                                'flex cursor-pointer items-center justify-between rounded-lg border p-2 text-sm',
+                                isSelected
+                                    ? 'border-amber-500 bg-amber-100 dark:bg-amber-900'
+                                    : 'border-amber-200 bg-white dark:bg-neutral-900',
+                            )}
+                        >
+                            <span>
+                                <strong>
+                                    {appointment.appointment_number}
+                                </strong>{' '}
+                                — {appointment.service?.name} (
+                                {appointment.priority_mode})
+                            </span>
+                            <input
+                                type="checkbox"
+                                checked={isSelected}
+                                onChange={() =>
+                                    onSelect(isSelected ? null : appointment)
+                                }
+                            />
+                        </label>
+                    );
+                })}
+            </div>
+        </div>
+    );
+}
+
+function BookAppointmentAccordion({ patient, services, providers }: any) {
+    const [open, setOpen] = useState(false);
+    const [serviceId, setServiceId] = useState<string>('');
+    const [doctorId, setDoctorId] = useState<string>('');
+    const [scheduledAt, setScheduledAt] = useState<string>('');
+    const [notes, setNotes] = useState<string>('');
+    const [processing, setProcessing] = useState(false);
+    const [errors, setErrors] = useState<any>({});
+
+    const selectedService = services.find((s: any) => s.id == serviceId);
+    const availableProviders = selectedService?.service_provider_types
+        ? (providers?.[selectedService.service_provider_types[0]] ?? [])
+        : [];
+
+    const submit = () => {
+        setProcessing(true);
+        setErrors({});
+        router.post(
+            appointmentStore().url,
+            {
+                patient_id: patient.id,
+                service_id: serviceId,
+                doctor_id: doctorId || null,
+                scheduled_at: scheduledAt,
+                notes: notes || null,
+            },
+            {
+                preserveScroll: true,
+                onSuccess: () => {
+                    toast.success('Appointment booked successfully.');
+                    setServiceId('');
+                    setDoctorId('');
+                    setScheduledAt('');
+                    setNotes('');
+                    setOpen(false);
+                },
+                onError: (validationErrors) => setErrors(validationErrors),
+                onFinish: () => setProcessing(false),
+            },
+        );
+    };
+
+    return (
+        <div className="mb-2 rounded-xl border p-4 dark:border-neutral-950">
+            <button
+                type="button"
+                className="flex w-full items-center justify-between text-left text-sm font-semibold"
+                onClick={() => setOpen(!open)}
+            >
+                <span>Book Future Appointment</span>
+                <span>{open ? '−' : '+'}</span>
+            </button>
+
+            {open && (
+                <div className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-2">
+                    <div className="grid gap-1">
+                        <Label htmlFor="appointment_service">Service</Label>
+                        <Select value={serviceId} onValueChange={setServiceId}>
+                            <SelectTrigger>
+                                <SelectValue placeholder="Select service" />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {services.map((service: any) => (
+                                    <SelectItem
+                                        key={service.id}
+                                        value={String(service.id)}
+                                    >
+                                        {service.name}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                        <InputError message={errors.service_id} />
+                    </div>
+
+                    {availableProviders.length > 0 && (
+                        <div className="grid gap-1">
+                            <Label htmlFor="appointment_doctor">
+                                Doctor (optional)
+                            </Label>
+                            <Select
+                                value={doctorId}
+                                onValueChange={setDoctorId}
+                            >
+                                <SelectTrigger>
+                                    <SelectValue placeholder="Any doctor" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {availableProviders.map((doctor: any) => (
+                                        <SelectItem
+                                            key={doctor.id}
+                                            value={String(doctor.id)}
+                                        >
+                                            {doctor.name}
+                                        </SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                        </div>
+                    )}
+
+                    <div className="grid gap-1">
+                        <Label htmlFor="appointment_scheduled_at">
+                            Date &amp; Time
+                        </Label>
+                        <Input
+                            id="appointment_scheduled_at"
+                            type="datetime-local"
+                            value={scheduledAt}
+                            onChange={(e) => setScheduledAt(e.target.value)}
+                        />
+                        <InputError message={errors.scheduled_at} />
+                    </div>
+
+                    <div className="grid gap-1">
+                        <Label htmlFor="appointment_notes">
+                            Notes (optional)
+                        </Label>
+                        <Input
+                            id="appointment_notes"
+                            type="text"
+                            value={notes}
+                            onChange={(e) => setNotes(e.target.value)}
+                        />
+                    </div>
+
+                    <div className="md:col-span-2">
+                        <Button
+                            type="button"
+                            onClick={submit}
+                            disabled={!serviceId || !scheduledAt || processing}
+                        >
+                            {processing && (
+                                <LoaderCircle className="mr-2 h-4 w-4 animate-spin" />
+                            )}
+                            Book Appointment
+                        </Button>
+                    </div>
+                </div>
+            )}
         </div>
     );
 }

--- a/resources/js/pages/hospital/opd-queue.tsx
+++ b/resources/js/pages/hospital/opd-queue.tsx
@@ -81,6 +81,13 @@ function cn(...classes) {
 
 function TokenCard({ item, variant = 'open', minify }) {
     const isNow = variant === 'in-progress';
+    // Medium-priority appointment reservations hold their queue spot before
+    // the patient arrives, but their identity must stay confidential on
+    // public LCD/queue boards until they actually check in (status flips
+    // from 'reserved' to 'open' at that point).
+    const isConfidential =
+        item.status?.toLowerCase() === 'reserved' &&
+        item.appointment?.priority_mode === 'medium';
     return (
         <div
             className={cn(
@@ -98,7 +105,9 @@ function TokenCard({ item, variant = 'open', minify }) {
                         {item.token_short ? item.token_short : item.so_short}
                     </div>
                     <div className="text-lg leading-tight font-semibold text-slate-900">
-                        {item.patient.name}
+                        {isConfidential
+                            ? 'Reserved Appointment'
+                            : item.patient.name}
                     </div>
                 </div>
 
@@ -114,7 +123,7 @@ function TokenCard({ item, variant = 'open', minify }) {
                 </span>
             </div>
 
-            {minify == false && (
+            {minify == false && !isConfidential && (
                 <>
                     {item.patient?.ps_number && minify == false ? (
                         <div className="text-xs text-slate-500">

--- a/routes/console.php
+++ b/routes/console.php
@@ -10,6 +10,10 @@ Artisan::command('inspire', function () {
 
 Schedule::command('app:close-old-service-orders')->everyFiveSeconds()->runInBackground()->withoutOverlapping();
 
+Schedule::command('app:materialize-appointments')->everyFiveMinutes()->runInBackground()->withoutOverlapping();
+
+Schedule::command('app:expire-no-show-appointments')->dailyAt('23:55')->runInBackground()->withoutOverlapping();
+
 Schedule::command('telescope:prune')->daily();
 
 Schedule::command('bank:link-transactions')->hourly()->runInBackground()->withoutOverlapping();

--- a/routes/web.php
+++ b/routes/web.php
@@ -90,7 +90,9 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
     Route::post('RECEAVEABLES-PAYMENT', [WebController::class, 'receaveablesPayment'])->name('receaveables-payment');
 
-    Route::get('appointments', [WebController::class, 'counter'])->name('appointments');
+    Route::post('APT-CREATE', [WebController::class, 'appointmentStore'])->name('appointment-store');
+    Route::post('APT-CANCEL/{appointment}', [WebController::class, 'appointmentCancel'])->name('appointment-cancel');
+    Route::get('appointments', [WebController::class, 'appointmentsCalendar'])->name('appointments-calendar');
     Route::get('expenses', [WebController::class, 'counter'])->name('expenses');
 
     /**

--- a/tests/Feature/AppointmentsTest.php
+++ b/tests/Feature/AppointmentsTest.php
@@ -1,0 +1,301 @@
+<?php
+
+use App\Enum\AppointmentPriorityMode;
+use App\Enum\AppointmentStatus;
+use App\Models\Appointment;
+use App\Models\Closing;
+use App\Models\HospitalSetting;
+use App\Models\Patient;
+use App\Models\Receaveable;
+use App\Models\Service;
+use App\Models\ServiceDepartment;
+use App\Models\ServiceOrder;
+use App\Models\User;
+use App\Services\AppointmentService;
+use Illuminate\Support\Facades\DB;
+
+function createOpdService(): Service
+{
+    $department = ServiceDepartment::factory()->create(['slug' => 'OPD']);
+
+    return Service::factory()->create([
+        'service_department_id' => $department->id,
+        'charges' => 500,
+    ]);
+}
+
+test('booking a priority appointment creates a draft receivable but no service order yet', function () {
+    HospitalSetting::set('appointment_priority_mode', AppointmentPriorityMode::Priority->value);
+
+    $service = createOpdService();
+    $patient = Patient::factory()->create();
+    $creator = User::factory()->create();
+
+    $appointment = app(AppointmentService::class)->book([
+        'patient_id' => $patient->id,
+        'service_id' => $service->id,
+        'scheduled_at' => now()->addDays(3),
+        'created_by' => $creator->id,
+    ]);
+
+    expect($appointment->priority_mode)->toBe(AppointmentPriorityMode::Priority);
+    expect($appointment->service_order_id)->toBeNull();
+    expect($appointment->receaveable_id)->not->toBeNull();
+
+    $receaveable = Receaveable::find($appointment->receaveable_id);
+    expect($receaveable->status)->toBe('draft');
+    expect((float) $receaveable->amount)->toBe(500.0);
+});
+
+test('booking a standard appointment creates no draft receivable', function () {
+    HospitalSetting::set('appointment_priority_mode', AppointmentPriorityMode::Standard->value);
+
+    $service = createOpdService();
+    $patient = Patient::factory()->create();
+    $creator = User::factory()->create();
+
+    $appointment = app(AppointmentService::class)->book([
+        'patient_id' => $patient->id,
+        'service_id' => $service->id,
+        'scheduled_at' => now()->addDay(),
+        'created_by' => $creator->id,
+    ]);
+
+    expect($appointment->priority_mode)->toBe(AppointmentPriorityMode::Standard);
+    expect($appointment->receaveable_id)->toBeNull();
+    expect($appointment->service_order_id)->toBeNull();
+});
+
+test('materialize command only reserves a service order for todays priority/medium appointments', function () {
+    $service = createOpdService();
+
+    $priorityToday = Appointment::factory()->priority()->scheduledToday()->create(['service_id' => $service->id]);
+    $mediumToday = Appointment::factory()->medium()->scheduledToday()->create(['service_id' => $service->id]);
+    $standardToday = Appointment::factory()->scheduledToday()->create(['service_id' => $service->id]);
+    $priorityFuture = Appointment::factory()->priority()->create([
+        'service_id' => $service->id,
+        'scheduled_at' => now()->addWeek(),
+    ]);
+
+    $this->artisan('app:materialize-appointments')->assertSuccessful();
+
+    $priorityToday->refresh();
+    $mediumToday->refresh();
+    $standardToday->refresh();
+    $priorityFuture->refresh();
+
+    expect($priorityToday->service_order_id)->not->toBeNull();
+    expect($priorityToday->serviceOrder->status)->toBe('reserved');
+    expect((int) $priorityToday->serviceOrder->priority)->toBe(1);
+
+    expect($mediumToday->service_order_id)->not->toBeNull();
+    expect((int) $mediumToday->serviceOrder->priority)->toBe(0);
+
+    expect($standardToday->service_order_id)->toBeNull();
+    expect($priorityFuture->service_order_id)->toBeNull();
+});
+
+test('a materialized priority reservation is ordered ahead of an earlier walk-in in the opd queue', function () {
+    $service = createOpdService();
+    $user = User::factory()->create();
+
+    $walkIn = ServiceOrder::factory()->create([
+        'type' => 'OPD',
+        'service_id' => $service->id,
+        'status' => 'open',
+        'created_at' => now()->subHour(),
+    ]);
+
+    $appointment = Appointment::factory()->priority()->scheduledToday()->create(['service_id' => $service->id]);
+    $this->artisan('app:materialize-appointments')->assertSuccessful();
+    $appointment->refresh();
+
+    $this->actingAs($user);
+    $response = $this->get(route('hospital-opd-queue'));
+    $response->assertOk();
+
+    $orders = $response->original->getData()['page']['props']['serviceOrdersByService'][$service->id];
+    $ids = collect($orders)->pluck('id')->toArray();
+
+    expect(array_search($appointment->service_order_id, $ids))->toBeLessThan(array_search($walkIn->id, $ids));
+});
+
+test('medium appointment reservations expose priority_mode so the frontend can mask identity', function () {
+    $service = createOpdService();
+    $user = User::factory()->create();
+
+    $appointment = Appointment::factory()->medium()->scheduledToday()->create(['service_id' => $service->id]);
+    $this->artisan('app:materialize-appointments')->assertSuccessful();
+    $appointment->refresh();
+
+    $this->actingAs($user);
+    $response = $this->get(route('hospital-opd-queue'));
+    $response->assertOk();
+
+    $orders = $response->original->getData()['page']['props']['serviceOrdersByService'][$service->id];
+    $reserved = collect($orders)->firstWhere('id', $appointment->service_order_id);
+
+    expect($reserved['status'])->toBe('reserved');
+    expect($reserved['appointment']['priority_mode'])->toBe('medium');
+});
+
+test('checking in a priority appointment settles the draft receivable and opens the reserved service order', function () {
+    HospitalSetting::set('appointment_priority_mode', AppointmentPriorityMode::Priority->value);
+
+    $service = createOpdService();
+    $patient = Patient::factory()->create();
+    $user = User::factory()->create();
+    Closing::factory()->create(['receptionist_id' => $user->id, 'status' => 'open']);
+
+    $appointment = app(AppointmentService::class)->book([
+        'patient_id' => $patient->id,
+        'service_id' => $service->id,
+        'scheduled_at' => now(),
+        'created_by' => $user->id,
+    ]);
+
+    $this->artisan('app:materialize-appointments')->assertSuccessful();
+    $appointment->refresh();
+
+    $reservedOrderId = $appointment->service_order_id;
+    $ordersBefore = ServiceOrder::count();
+
+    $this->actingAs($user);
+    $response = $this->post(route('transaction-store'), [
+        'income_or_expense' => 'INCOME',
+        'patient_id' => $patient->id,
+        'department_key' => 'OPD',
+        'appointment_id' => $appointment->id,
+        'total_amount' => 500,
+        'payment_method' => 'CASH',
+        'amount_paid' => 500,
+        'items' => [
+            ['service_id' => $service->id, 'quantity' => 1, 'total' => 500],
+        ],
+    ]);
+
+    $response->assertRedirect();
+
+    expect(ServiceOrder::count())->toBe($ordersBefore); // no duplicate order created
+
+    $appointment->refresh();
+    expect($appointment->status)->toBe(AppointmentStatus::CheckedIn);
+    expect($appointment->checked_in_at)->not->toBeNull();
+
+    $reservedOrder = ServiceOrder::find($reservedOrderId);
+    expect($reservedOrder->status)->toBe('open');
+
+    $receaveable = Receaveable::find($appointment->receaveable_id);
+    expect($receaveable->status)->toBe('paid');
+});
+
+test('expiring a no-show priority appointment cancels its draft receivable and closes its reserved slot', function () {
+    HospitalSetting::set('appointment_priority_mode', AppointmentPriorityMode::Priority->value);
+
+    $service = createOpdService();
+    $patient = Patient::factory()->create();
+    $user = User::factory()->create();
+
+    $appointment = app(AppointmentService::class)->book([
+        'patient_id' => $patient->id,
+        'service_id' => $service->id,
+        'scheduled_at' => now(),
+        'created_by' => $user->id,
+    ]);
+
+    $this->artisan('app:materialize-appointments')->assertSuccessful();
+    $appointment->refresh();
+
+    $this->artisan('app:expire-no-show-appointments')->assertSuccessful();
+
+    $appointment->refresh();
+    expect($appointment->status)->toBe(AppointmentStatus::NoShow);
+
+    $receaveable = Receaveable::find($appointment->receaveable_id);
+    expect($receaveable->status)->toBe('cancelled');
+
+    $serviceOrder = ServiceOrder::find($appointment->service_order_id);
+    expect($serviceOrder->status)->toBe('CLOSED');
+    expect($serviceOrder->closed_at)->not->toBeNull();
+});
+
+test('cancelling a scheduled appointment cancels its draft receivable', function () {
+    HospitalSetting::set('appointment_priority_mode', AppointmentPriorityMode::Priority->value);
+
+    $service = createOpdService();
+    $patient = Patient::factory()->create();
+    $user = User::factory()->create();
+
+    $appointment = app(AppointmentService::class)->book([
+        'patient_id' => $patient->id,
+        'service_id' => $service->id,
+        'scheduled_at' => now()->addDays(2),
+        'created_by' => $user->id,
+    ]);
+
+    $this->actingAs($user);
+    $response = $this->post(route('appointment-cancel', ['appointment' => $appointment->id]));
+    $response->assertRedirect();
+
+    $appointment->refresh();
+    expect($appointment->status)->toBe(AppointmentStatus::Cancelled);
+
+    $receaveable = Receaveable::find($appointment->receaveable_id);
+    expect($receaveable->status)->toBe('cancelled');
+});
+
+test('a draft receivable is excluded from the generic receivables PDF report', function () {
+    $patient = Patient::factory()->create();
+
+    Receaveable::factory()->create([
+        'patient_id' => $patient->id,
+        'amount' => 1000,
+        'orignal_amount' => 1000,
+        'status' => 'draft',
+    ]);
+
+    Receaveable::factory()->create([
+        'patient_id' => $patient->id,
+        'amount' => 200,
+        'orignal_amount' => 200,
+        'status' => 'unpaid',
+    ]);
+
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    DB::enableQueryLog();
+
+    $response = $this->get('/reports/generic/receivables?from='.now()->subDay()->toDateString().'&until='.now()->addDay()->toDateString());
+    $response->assertOk();
+
+    $receaveableQuery = collect(DB::getQueryLog())
+        ->first(fn ($entry) => str_contains($entry['query'], 'receaveables') && str_contains($entry['query'], 'select'));
+
+    DB::disableQueryLog();
+
+    expect($receaveableQuery['query'])->toContain('"status" != ?');
+    expect($receaveableQuery['bindings'])->toContain('draft');
+});
+
+test('a draft receivable is excluded from the financial KPI outstanding receivables stat', function () {
+    $patient = Patient::factory()->create();
+
+    Receaveable::factory()->create([
+        'patient_id' => $patient->id,
+        'amount' => 5000,
+        'orignal_amount' => 5000,
+        'status' => 'draft',
+    ]);
+
+    Receaveable::factory()->create([
+        'patient_id' => $patient->id,
+        'amount' => 300,
+        'orignal_amount' => 300,
+        'status' => 'unpaid',
+    ]);
+
+    $outstanding = Receaveable::whereNotIn('status', ['paid', 'cancelled', 'draft'])->sum('amount');
+
+    expect((float) $outstanding)->toBe(300.0);
+});


### PR DESCRIPTION
## Summary
- New `Appointment` model + booking flow with three hospital-wide configurable priority modes (set in Hospital Settings): **Priority** (draft receivable + top-of-queue reservation), **Medium** (reserved queue slot with identity masked on LCD/queue boards until check-in), **Standard** (informational only, no queue/financial effect).
- Booking is added as an accordion on the existing Counter Income screen (not a separate page); check-in reuses the reserved service order and settles the draft receivable instead of duplicating it.
- Two scheduled commands: `app:materialize-appointments` (turns today's Priority/Medium appointments into live queue slots) and `app:expire-no-show-appointments` (end-of-day cleanup — cancels drafts, closes reserved slots).
- Draft receivables are excluded from every reporting/dashboard/export surface that touches `Receaveable` (Filament widgets, PDF/Excel reports, the Receaveables resource).
- New reception-facing Appointments calendar page (`/appointments`) with day-detail view and cancel action, plus a sidebar nav entry.
- New Filament Appointments admin resource (list/view/cancel) for oversight.

## Test plan
- [x] `php artisan test --compact` — 629 passed, 1 pre-existing unrelated failure (`AbacusClosingIntegrationTest`, confirmed failing on `main` before this branch too)
- [x] 10 new Pest feature tests covering booking, materialization, queue priority ordering, identity masking, check-in/payment reconciliation, no-show expiry, and reporting exclusion
- [x] `vendor/bin/pint --dirty` clean
- [x] `eslint`/`tsc` clean on all touched frontend files (no new errors)
- [x] Migrations verified against a fresh database

🤖 Generated with [Claude Code](https://claude.com/claude-code)