### PR TITLE
Department search prefill, colored triage radios, tighter PDF padding

### DIFF
--- a/app/Http/Controllers/Api/DepartmentController.php
+++ b/app/Http/Controllers/Api/DepartmentController.php
@@ -220,6 +220,8 @@ class DepartmentController extends Controller
      *   - "PS/{y}/{m}/{n}" (plain patient number) → patient.ps_number
      *   - starts with "SO" → so_number
      *   - starts with "TR" → transaction number, resolved to its service order(s)
+     *   - "{DEPT}/{digits}" (e.g. "EMG/0000133" — the dashboard's search-box
+     *     prefill, the department's current so_short minus its last digit) → so_short
      *   - all-digits → so_short
      *   - anything else → patient name
      *
@@ -256,13 +258,15 @@ class DepartmentController extends Controller
                 ->whereNotNull('service_order_id')
                 ->pluck('service_order_id');
             $query->whereIn('id', $serviceOrderIds);
+        } elseif (preg_match('/^[A-Za-z]+\/\d+$/', $q)) {
+            $query->where('so_short', 'like', "{$q}%");
         } elseif (ctype_digit($q)) {
             $query->where('so_short', 'like', "{$q}%");
         } else {
             $query->whereHas('patient', fn ($pq) => $pq->where('name', 'like', "%{$q}%"));
         }
 
-        $results = $query->latest('id')->limit(15)->get();
+        $results = $query->latest('id')->limit(20)->get();
 
         return response()->json(['data' => $results->values()]);
     }

--- a/app/Http/Controllers/Api/IndController.php
+++ b/app/Http/Controllers/Api/IndController.php
@@ -28,7 +28,7 @@ class IndController extends Controller
         ]);
 
         $query = trim($filters['q']);
-        $limit = $filters['limit'] ?? 10;
+        $limit = $filters['limit'] ?? 20;
 
         $exact = collect();
         $possible = collect();
@@ -64,11 +64,15 @@ class IndController extends Controller
             }
         }
 
+        // Partial SO number / so_short match — so_short is what the dashboard
+        // pre-fills the search box with (department prefix + running
+        // sequence minus the last digit), so staff only need to type the end.
         if ($exact->isEmpty() && $possible->isEmpty()) {
             $possible = ServiceOrder::query()
                 ->with(['patient:id,name,ps_number,gender,age_days,age_dob', 'service:id,name'])
                 ->where('type', 'IND')
-                ->where('so_number', 'like', "%{$query}%")
+                ->where(fn ($q) => $q->where('so_number', 'like', "%{$query}%")
+                    ->orWhere('so_short', 'like', "{$query}%"))
                 ->latest('created_at')
                 ->limit($limit)
                 ->get();

--- a/app/Http/Controllers/Api/OpdController.php
+++ b/app/Http/Controllers/Api/OpdController.php
@@ -27,7 +27,7 @@ class OpdController extends Controller
         ]);
 
         $query = trim($filters['q']);
-        $limit = $filters['limit'] ?? 10;
+        $limit = $filters['limit'] ?? 20;
 
         $exact = collect();
         $possible = collect();
@@ -66,12 +66,15 @@ class OpdController extends Controller
             }
         }
 
-        // Partial SO number match
+        // Partial SO number / so_short match — so_short is what the dashboard
+        // pre-fills the search box with (department prefix + running
+        // sequence minus the last digit), so staff only need to type the end.
         if ($exact->isEmpty() && $possible->isEmpty()) {
             $possible = ServiceOrder::query()
                 ->with(['patient:id,name,ps_number,gender,age_days,age_dob', 'service:id,name'])
                 ->where('type', 'OPD')
-                ->where('so_number', 'like', "%{$query}%")
+                ->where(fn ($q) => $q->where('so_number', 'like', "%{$query}%")
+                    ->orWhere('so_short', 'like', "{$query}%"))
                 ->latest('created_at')
                 ->limit($limit)
                 ->get();

--- a/app/Http/Controllers/DentistController.php
+++ b/app/Http/Controllers/DentistController.php
@@ -43,6 +43,7 @@ class DentistController extends Controller
             'isDentist' => $isDentist,
             'recentOrders' => $recentOrders->values(),
             'todayStats' => $todayStats,
+            'searchPrefill' => ServiceOrder::latestSoShortPrefix(['DNT'], 'DNT'),
         ]);
     }
 

--- a/app/Http/Controllers/EmergencyDoctorController.php
+++ b/app/Http/Controllers/EmergencyDoctorController.php
@@ -51,6 +51,7 @@ class EmergencyDoctorController extends Controller
             'isDoctorScoped' => $isEmgDoctor,
             'recentOrders' => $recentOrders->values(),
             'todayStats' => $todayStats,
+            'searchPrefill' => ServiceOrder::latestSoShortPrefix(['EMG'], 'EMG'),
         ]);
     }
 

--- a/app/Http/Controllers/IndDoctorController.php
+++ b/app/Http/Controllers/IndDoctorController.php
@@ -54,6 +54,7 @@ class IndDoctorController extends Controller
             'isIndDoctor' => $isIndDoctor,
             'wards' => $wards,
             'unassignedQueue' => $unassignedQueue->values(),
+            'searchPrefill' => ServiceOrder::latestSoShortPrefix(['IND'], 'IND'),
         ]);
     }
 

--- a/app/Http/Controllers/LabController.php
+++ b/app/Http/Controllers/LabController.php
@@ -44,6 +44,7 @@ class LabController extends Controller
             'hasAccess' => $hasAccess,
             'recentOrders' => $recentOrders->values(),
             'todayStats' => $todayStats,
+            'searchPrefill' => ServiceOrder::latestSoShortPrefix(['PTH'], 'PTH'),
         ]);
     }
 

--- a/app/Http/Controllers/OpdDoctorController.php
+++ b/app/Http/Controllers/OpdDoctorController.php
@@ -45,6 +45,7 @@ class OpdDoctorController extends Controller
             'isOpdDoctor' => $isOpdDoctor,
             'recentOrders' => $recentOrders->values(),
             'todayStats' => $todayStats,
+            'searchPrefill' => ServiceOrder::latestSoShortPrefix(['OPD'], 'OPD'),
         ]);
     }
 

--- a/app/Http/Controllers/UltrasoundController.php
+++ b/app/Http/Controllers/UltrasoundController.php
@@ -43,6 +43,7 @@ class UltrasoundController extends Controller
             'isUltDoctor' => $isUltDoctor,
             'recentOrders' => $recentOrders->values(),
             'todayStats' => $todayStats,
+            'searchPrefill' => ServiceOrder::latestSoShortPrefix(['ULT'], 'ULT'),
         ]);
     }
 

--- a/app/Http/Controllers/XrayController.php
+++ b/app/Http/Controllers/XrayController.php
@@ -43,6 +43,7 @@ class XrayController extends Controller
             'isXrayTech' => $isXrayTech,
             'recentOrders' => $recentOrders->values(),
             'todayStats' => $todayStats,
+            'searchPrefill' => ServiceOrder::latestSoShortPrefix(['XRAY', 'RAD'], 'XRAY'),
         ]);
     }
 

--- a/app/Models/ServiceOrder.php
+++ b/app/Models/ServiceOrder.php
@@ -306,6 +306,24 @@ class ServiceOrder extends Model
         });
     }
 
+    /**
+     * The department's current so_short with its last digit stripped, e.g.
+     * "EMG/0000133" for latest so_short "EMG/00001334" — used to pre-fill a
+     * department dashboard's search box so staff only need to type the
+     * digit(s) that differ from the most recent order they already know.
+     * Falls back to a zero-based prefix when the department has no orders yet.
+     */
+    public static function latestSoShortPrefix(array $types, string $fallbackType): string
+    {
+        $latest = self::whereIn('type', $types)->latest('id')->value('so_short');
+
+        if (empty($latest)) {
+            return "{$fallbackType}/0000000";
+        }
+
+        return strlen($latest) > 1 ? substr($latest, 0, -1) : $latest;
+    }
+
     public function expenseVouchers(): BelongsToMany
     {
         return $this->belongsToMany(ExpenseVoucher::class, 'expense_voucher_service_order')

--- a/resources/js/elements/dept-portal/DeptPatientForm.tsx
+++ b/resources/js/elements/dept-portal/DeptPatientForm.tsx
@@ -3,13 +3,7 @@ import DentalChart, {
 } from '@/components/ui/dental-chart';
 import DrugPicker from '@/components/ui/drug-picker';
 import Icd10Picker from '@/components/ui/icd10-picker';
-import {
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue,
-} from '@/components/ui/select';
+import { RadioInput } from '@/components/ui/input-radio';
 import TreatmentAttachments, {
     type TreatmentAttachmentData,
 } from '@/components/ui/treatment-attachments';
@@ -19,8 +13,10 @@ import {
 } from '@/elements/dept-portal/DischargeDialog';
 import {
     formatPatientAge,
+    triageAccentClass,
     triageBadgeClass,
     triageDotClass,
+    triageSelectedClass,
 } from '@/lib/constants';
 import { printServiceorder } from '@/routes';
 import { router } from '@inertiajs/react';
@@ -919,82 +915,76 @@ export default function DeptPatientForm({
                         >
                             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                                 {showTriage && (
-                                    <div>
-                                        <label className="mb-1 block text-xs font-medium text-slate-500">
+                                    <div className="sm:col-span-2">
+                                        <label className="mb-1.5 block text-xs font-medium text-slate-500">
                                             Triage Level{' '}
                                             <span className="text-red-500">
                                                 *
                                             </span>
                                         </label>
-                                        <Select
-                                            disabled={isFinalized}
-                                            value={
-                                                triageId ? String(triageId) : ''
-                                            }
-                                            onValueChange={(value) => {
-                                                const newId = value
-                                                    ? Number(value)
-                                                    : null;
-                                                const newTriage = triages.find(
-                                                    (t) => t.id === newId,
-                                                );
-                                                if (
-                                                    newTriage?.color === 'black'
-                                                ) {
-                                                    setPendingBlackTriageId(
-                                                        newId,
-                                                    );
-                                                    setDeathConfirmOpen(true);
-                                                } else {
-                                                    setTriageId(newId);
-                                                }
-                                            }}
+                                        <div
+                                            role="radiogroup"
+                                            aria-label="Triage Level"
+                                            className="flex flex-wrap gap-2"
                                         >
-                                            <SelectTrigger className="w-full">
-                                                <SelectValue placeholder="Select triage level…" />
-                                            </SelectTrigger>
-                                            <SelectContent>
-                                                {triages.map((t) => (
-                                                    <SelectItem
+                                            {triages.map((t) => {
+                                                const selected =
+                                                    triageId === t.id;
+                                                return (
+                                                    <label
                                                         key={t.id}
-                                                        value={String(t.id)}
+                                                        className={clsx(
+                                                            'flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-medium transition-colors',
+                                                            isFinalized
+                                                                ? 'cursor-not-allowed opacity-50'
+                                                                : 'cursor-pointer hover:bg-slate-50',
+                                                            selected
+                                                                ? triageSelectedClass(
+                                                                      t.color,
+                                                                  )
+                                                                : 'border-slate-200 bg-white',
+                                                        )}
                                                     >
-                                                        <span className="flex items-center gap-2">
-                                                            <span
-                                                                className={clsx(
-                                                                    'h-2.5 w-2.5 shrink-0 rounded-full',
-                                                                    triageDotClass(
-                                                                        t.color,
-                                                                    ),
-                                                                )}
-                                                            />
-                                                            {t.name}
-                                                        </span>
-                                                    </SelectItem>
-                                                ))}
-                                            </SelectContent>
-                                        </Select>
-                                        {triageId && (
-                                            <span
-                                                className={clsx(
-                                                    'mt-1.5 inline-block rounded-full px-2 py-0.5 text-xs font-semibold ring-1',
-                                                    triageBadgeClass(
-                                                        triages.find(
-                                                            (t) =>
-                                                                t.id ===
-                                                                triageId,
-                                                        )?.color,
-                                                    ),
-                                                )}
-                                            >
-                                                {
-                                                    triages.find(
-                                                        (t) =>
-                                                            t.id === triageId,
-                                                    )?.name
-                                                }
-                                            </span>
-                                        )}
+                                                        <RadioInput
+                                                            name="triage_level"
+                                                            disabled={
+                                                                isFinalized
+                                                            }
+                                                            checked={selected}
+                                                            className={triageAccentClass(
+                                                                t.color,
+                                                            )}
+                                                            onChange={() => {
+                                                                if (
+                                                                    t.color ===
+                                                                    'black'
+                                                                ) {
+                                                                    setPendingBlackTriageId(
+                                                                        t.id,
+                                                                    );
+                                                                    setDeathConfirmOpen(
+                                                                        true,
+                                                                    );
+                                                                } else {
+                                                                    setTriageId(
+                                                                        t.id,
+                                                                    );
+                                                                }
+                                                            }}
+                                                        />
+                                                        <span
+                                                            className={clsx(
+                                                                'h-2.5 w-2.5 shrink-0 rounded-full',
+                                                                triageDotClass(
+                                                                    t.color,
+                                                                ),
+                                                            )}
+                                                        />
+                                                        {t.name}
+                                                    </label>
+                                                );
+                                            })}
+                                        </div>
                                     </div>
                                 )}
                                 {requireTreatmentTime && (

--- a/resources/js/elements/dept-portal/DeptQueueDashboard.tsx
+++ b/resources/js/elements/dept-portal/DeptQueueDashboard.tsx
@@ -57,6 +57,7 @@ interface Props {
     myQueueUrl: string; // GET — /api/{dept}/my-queue?types[]=...
     searchApiUrl: string; // POST — /api/{dept}/search
     searchTypes: string[]; // SO types to search, e.g. ['EMG']
+    searchPrefill?: string; // department's current so_short minus its last digit
     doctorScoped?: boolean; // whether queue is filtered by doctor_id (default true)
     showCallButton?: boolean; // departments like EMG don't call patients by turn (default true)
     flashError?: string;
@@ -109,6 +110,7 @@ export default function DeptQueueDashboard({
     myQueueUrl,
     searchApiUrl,
     searchTypes,
+    searchPrefill,
     doctorScoped = true,
     showCallButton = true,
     flashError,
@@ -116,7 +118,7 @@ export default function DeptQueueDashboard({
 }: Props) {
     const [orders, setOrders] = useState<DeptOrder[]>(initialOrders ?? []);
     const [stats, setStats] = useState(initialStats);
-    const [searchQuery, setSearchQuery] = useState('');
+    const [searchQuery, setSearchQuery] = useState(searchPrefill ?? '');
     const [searchResults, setSearchResults] = useState<DeptOrder[] | null>(
         null,
     );
@@ -181,6 +183,13 @@ export default function DeptQueueDashboard({
         },
         [searchApiUrl, searchTypes],
     );
+
+    // Run the pre-filled search immediately on load so staff see the latest
+    // matching service orders straight away instead of an empty list.
+    useEffect(() => {
+        if (searchPrefill) handleSearch(searchPrefill);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     const onSearchInput = (e: React.ChangeEvent<HTMLInputElement>) => {
         const v = e.target.value;

--- a/resources/js/lib/constants.ts
+++ b/resources/js/lib/constants.ts
@@ -84,3 +84,34 @@ const TRIAGE_DOT_CLASSES: Record<string, string> = {
 export function triageDotClass(color?: string | null): string {
     return TRIAGE_DOT_CLASSES[color ?? ''] ?? 'bg-slate-400';
 }
+
+const TRIAGE_ACCENT_CLASSES: Record<string, string> = {
+    red: 'text-red-600',
+    yellow: 'text-yellow-500',
+    blue: 'text-blue-600',
+    sky: 'text-sky-500',
+    green: 'text-green-600',
+    black: 'text-slate-900',
+};
+
+/** Tailwind text-color class controlling a native radio input's accent color, keyed by triage color name. */
+export function triageAccentClass(color?: string | null): string {
+    return TRIAGE_ACCENT_CLASSES[color ?? ''] ?? 'text-slate-500';
+}
+
+const TRIAGE_SELECTED_CLASSES: Record<string, string> = {
+    red: 'border-red-300 bg-red-50 ring-1 ring-red-200',
+    yellow: 'border-yellow-300 bg-yellow-50 ring-1 ring-yellow-200',
+    blue: 'border-blue-300 bg-blue-50 ring-1 ring-blue-200',
+    sky: 'border-sky-300 bg-sky-50 ring-1 ring-sky-200',
+    green: 'border-green-300 bg-green-50 ring-1 ring-green-200',
+    black: 'border-slate-500 bg-slate-100 ring-1 ring-slate-400',
+};
+
+/** Tailwind classes for a triage radio pill's selected state, keyed by triage color name. */
+export function triageSelectedClass(color?: string | null): string {
+    return (
+        TRIAGE_SELECTED_CLASSES[color ?? ''] ??
+        'border-slate-400 bg-slate-100 ring-1 ring-slate-300'
+    );
+}

--- a/resources/js/pages/dnt/index.tsx
+++ b/resources/js/pages/dnt/index.tsx
@@ -15,7 +15,8 @@ const breadcrumbs = [
 ];
 
 export default function DntDashboard() {
-    const { isDentist, recentOrders, todayStats, flash } = usePage<any>().props;
+    const { isDentist, recentOrders, todayStats, searchPrefill, flash } =
+        usePage<any>().props;
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
             <Head title="Dental Portal" />
@@ -39,6 +40,7 @@ export default function DntDashboard() {
                 myQueueUrl={apiDntMyQueue().url}
                 searchApiUrl={apiDntSearch().url}
                 searchTypes={['DNT']}
+                searchPrefill={searchPrefill}
                 flashError={(flash as any)?.searchError}
             />
         </AppLayout>

--- a/resources/js/pages/emg/index.tsx
+++ b/resources/js/pages/emg/index.tsx
@@ -15,8 +15,14 @@ const breadcrumbs = [
 ];
 
 export default function EmgDashboard() {
-    const { isEmgDoctor, isDoctorScoped, recentOrders, todayStats, flash } =
-        usePage<any>().props;
+    const {
+        isEmgDoctor,
+        isDoctorScoped,
+        recentOrders,
+        todayStats,
+        searchPrefill,
+        flash,
+    } = usePage<any>().props;
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
             <Head title="Emergency Portal" />
@@ -40,6 +46,7 @@ export default function EmgDashboard() {
                 myQueueUrl={apiEmgMyQueue().url}
                 searchApiUrl={apiEmgSearch().url}
                 searchTypes={['EMG']}
+                searchPrefill={searchPrefill}
                 doctorScoped={isDoctorScoped}
                 showCallButton={false}
                 flashError={(flash as any)?.searchError}

--- a/resources/js/pages/ind/index.tsx
+++ b/resources/js/pages/ind/index.tsx
@@ -88,6 +88,7 @@ interface IndDashboardProps {
     isIndDoctor: boolean;
     wards: WardData[];
     unassignedQueue: IndServiceOrder[];
+    searchPrefill: string;
     [key: string]: unknown;
 }
 
@@ -159,11 +160,12 @@ export default function IndDashboard() {
         isIndDoctor,
         wards: initialWards,
         unassignedQueue: initialQueue,
+        searchPrefill,
     } = usePage<IndDashboardProps>().props;
 
     const [wards, setWards] = useState<WardData[]>(initialWards ?? []);
     const [queue, setQueue] = useState<IndServiceOrder[]>(initialQueue ?? []);
-    const [searchQuery, setSearchQuery] = useState('');
+    const [searchQuery, setSearchQuery] = useState(searchPrefill ?? '');
     const [searchResults, setSearchResults] = useState<{
         exact: IndServiceOrder[];
         possible: IndServiceOrder[];
@@ -253,6 +255,13 @@ export default function IndDashboard() {
         } finally {
             setSearching(false);
         }
+    }, []);
+
+    // Run the pre-filled search immediately on load so staff see the latest
+    // matching service orders straight away instead of an empty list.
+    useEffect(() => {
+        if (searchPrefill) handleSearch(searchPrefill);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     const onSearchInput = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/resources/js/pages/lab/index.tsx
+++ b/resources/js/pages/lab/index.tsx
@@ -15,7 +15,8 @@ const breadcrumbs = [
 ];
 
 export default function LabDashboard() {
-    const { hasAccess, recentOrders, todayStats, flash } = usePage<any>().props;
+    const { hasAccess, recentOrders, todayStats, searchPrefill, flash } =
+        usePage<any>().props;
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
             <Head title="Laboratory Portal" />
@@ -39,6 +40,7 @@ export default function LabDashboard() {
                 myQueueUrl={apiLabMyQueue().url}
                 searchApiUrl={apiLabSearch().url}
                 searchTypes={['PTH']}
+                searchPrefill={searchPrefill}
                 doctorScoped={false}
                 flashError={(flash as any)?.searchError}
             />

--- a/resources/js/pages/opd/index.tsx
+++ b/resources/js/pages/opd/index.tsx
@@ -51,6 +51,7 @@ interface OpdDashboardProps {
         treated: number;
         total: number;
     };
+    searchPrefill: string;
     [key: string]: unknown;
 }
 
@@ -123,6 +124,7 @@ export default function OpdDashboard() {
         isOpdDoctor,
         recentOrders: initialOrders,
         todayStats: initialStats,
+        searchPrefill,
         flash,
     } = usePage<OpdDashboardProps>().props;
 
@@ -130,7 +132,7 @@ export default function OpdDashboard() {
         initialOrders ?? [],
     );
     const [stats, setStats] = useState(initialStats);
-    const [searchQuery, setSearchQuery] = useState('');
+    const [searchQuery, setSearchQuery] = useState(searchPrefill ?? '');
     const [searchResults, setSearchResults] = useState<{
         exact: OpdServiceOrder[];
         possible: OpdServiceOrder[];
@@ -198,6 +200,13 @@ export default function OpdDashboard() {
         } finally {
             setSearching(false);
         }
+    }, []);
+
+    // Run the pre-filled search immediately on load so staff see the latest
+    // matching service orders straight away instead of an empty list.
+    useEffect(() => {
+        if (searchPrefill) handleSearch(searchPrefill);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     const onSearchInput = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/resources/js/pages/ult/index.tsx
+++ b/resources/js/pages/ult/index.tsx
@@ -15,7 +15,7 @@ const breadcrumbs = [
 ];
 
 export default function UltDashboard() {
-    const { isUltDoctor, recentOrders, todayStats, flash } =
+    const { isUltDoctor, recentOrders, todayStats, searchPrefill, flash } =
         usePage<any>().props;
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
@@ -40,6 +40,7 @@ export default function UltDashboard() {
                 myQueueUrl={apiUltMyQueue().url}
                 searchApiUrl={apiUltSearch().url}
                 searchTypes={['ULT']}
+                searchPrefill={searchPrefill}
                 flashError={(flash as any)?.searchError}
             />
         </AppLayout>

--- a/resources/js/pages/xray/index.tsx
+++ b/resources/js/pages/xray/index.tsx
@@ -15,7 +15,7 @@ const breadcrumbs = [
 ];
 
 export default function XrayDashboard() {
-    const { isXrayTech, recentOrders, todayStats, flash } =
+    const { isXrayTech, recentOrders, todayStats, searchPrefill, flash } =
         usePage<any>().props;
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
@@ -40,6 +40,7 @@ export default function XrayDashboard() {
                 myQueueUrl={apiXrayMyQueue().url}
                 searchApiUrl={apiXraySearch().url}
                 searchTypes={['XRAY', 'RAD']}
+                searchPrefill={searchPrefill}
                 flashError={(flash as any)?.searchError}
             />
         </AppLayout>

--- a/resources/views/pdfs/serviceorder.blade.php
+++ b/resources/views/pdfs/serviceorder.blade.php
@@ -11,7 +11,11 @@
         $treatingDoctorName .= " (PMDC# {$treatingDoctor->pmdc_number})";
     }
     $prescriptions = $tr?->prescriptions ?? [];
-    $drugRowCount = max(5, count($prescriptions));
+    // Blank forms keep a full set of writing lines for alignment when printed
+    // before any treatment is recorded; once real entries exist, only pad
+    // with one trailing blank row instead of filling out to the minimum.
+    $drugRowCount = count($prescriptions) > 0 ? count($prescriptions) + 1 : 5;
+    $treatmentGivenRowCount = $tr?->treatment_plan ? 2 : 7;
     $outcomeValue = $tr?->outcome?->value;
     $checked = fn (string $value) => $outcomeValue === $value ? 'X' : '';
 @endphp
@@ -435,7 +439,7 @@
                 <td class="bold" style="width:30%;">INVESTIGATION DONE:</td>
             </tr>
 
-            @for($i=0; $i<7; $i++)
+            @for($i=0; $i<$treatmentGivenRowCount; $i++)
                 <tr>
                     <td>{{ $i === 0 ? $tr?->treatment_plan : '' }}</td>
                     <td></td>

--- a/tests/Feature/Api/DepartmentSearchPrefixTest.php
+++ b/tests/Feature/Api/DepartmentSearchPrefixTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use App\Models\EmergencyDoctor;
+use App\Models\IndDoctor;
+use App\Models\OpdDoctor;
+use App\Models\ServiceOrder;
+use App\Models\User;
+
+test('ServiceOrder::latestSoShortPrefix returns the latest so_short minus its last digit', function () {
+    ServiceOrder::factory()->create(['type' => 'EMG', 'so_short' => 'EMG/00001333']);
+    ServiceOrder::factory()->create(['type' => 'EMG', 'so_short' => 'EMG/00001334']);
+
+    expect(ServiceOrder::latestSoShortPrefix(['EMG'], 'EMG'))->toBe('EMG/0000133');
+});
+
+test('ServiceOrder::latestSoShortPrefix falls back to a zero prefix when the department has no orders yet', function () {
+    expect(ServiceOrder::latestSoShortPrefix(['ULT'], 'ULT'))->toBe('ULT/0000000');
+});
+
+test('opd search by so_short prefix matches partial results', function () {
+    $doctor = User::factory()->create();
+    OpdDoctor::factory()->create(['user_id' => $doctor->id]);
+    $this->actingAs($doctor);
+
+    $match = ServiceOrder::factory()->create(['type' => 'OPD', 'so_short' => 'OPD/00001334']);
+    ServiceOrder::factory()->create(['type' => 'OPD', 'so_short' => 'OPD/00009999']);
+
+    $response = $this->postJson('/api/opd/search', ['q' => 'OPD/000013']);
+
+    $response->assertOk();
+    $ids = collect($response->json('data.possible'))->pluck('id');
+    expect($ids)->toContain($match->id);
+});
+
+test('ind search by so_short prefix matches partial results', function () {
+    $doctor = User::factory()->create();
+    IndDoctor::factory()->create(['user_id' => $doctor->id]);
+    $this->actingAs($doctor);
+
+    $match = ServiceOrder::factory()->create(['type' => 'IND', 'so_short' => 'IND/00000042']);
+    ServiceOrder::factory()->create(['type' => 'IND', 'so_short' => 'IND/00009999']);
+
+    $response = $this->postJson('/api/ind/search', ['q' => 'IND/000000']);
+
+    $response->assertOk();
+    $ids = collect($response->json('data.possible'))->pluck('id');
+    expect($ids)->toContain($match->id);
+});
+
+test('department search by dept-prefixed digits term matches so_short', function () {
+    $doctor = User::factory()->create();
+    EmergencyDoctor::factory()->create(['user_id' => $doctor->id]);
+    $this->actingAs($doctor);
+
+    $match = ServiceOrder::factory()->create(['type' => 'EMG', 'so_short' => 'EMG/00001334']);
+    ServiceOrder::factory()->create(['type' => 'EMG', 'so_short' => 'EMG/00009999']);
+
+    $response = $this->postJson('/api/emg/search', ['q' => 'EMG/0000133', 'types' => ['EMG']]);
+
+    $response->assertOk();
+    $ids = collect($response->json('data'))->pluck('id');
+    expect($ids)->toContain($match->id)->toHaveCount(1);
+});
+
+test('opd dashboard passes a searchPrefill prop derived from the latest so_short', function () {
+    $doctor = User::factory()->create();
+    OpdDoctor::factory()->create(['user_id' => $doctor->id]);
+    $this->actingAs($doctor);
+
+    ServiceOrder::factory()->create(['type' => 'OPD', 'so_short' => 'OPD/00001334']);
+
+    $response = $this->get(route('opd-dashboard'));
+
+    $response->assertOk();
+    expect($response->original->getData()['page']['props']['searchPrefill'])->toBe('OPD/0000133');
+});

--- a/tests/Feature/Prints/ServiceOrderPdfPrintTest.php
+++ b/tests/Feature/Prints/ServiceOrderPdfPrintTest.php
@@ -255,3 +255,67 @@ test('the drug chart uses each prescription\'s own given_at time instead of the 
     // doctor), so just confirm the drug's own given_at time is present.
     expect($html)->toContain(DateHelper::pdfFormat($givenAt, 'H:i'));
 });
+
+function rowCountBetween(string $html, string $startMarker, string $endMarker): int
+{
+    $start = strpos($html, $startMarker);
+    $end = strpos($html, $endMarker, $start);
+    $segment = substr($html, $start, $end - $start);
+
+    return substr_count($segment, '<tr>');
+}
+
+test('drug chart keeps a full set of blank writing lines when no prescriptions exist yet', function () {
+    $serviceOrder = ServiceOrder::factory()->create(['type' => 'EMG']);
+
+    $html = view('pdfs.serviceorder', ['serviceOrder' => $serviceOrder->fresh(['patient', 'doctor']), 'patient' => $serviceOrder->patient])->render();
+
+    // 1 header row + 5 blank alignment rows.
+    expect(rowCountBetween($html, '<table class="drug-table">', '</table>'))->toBe(6);
+});
+
+test('drug chart only pads with one blank row once prescriptions are recorded', function () {
+    $serviceOrder = ServiceOrder::factory()->create(['type' => 'EMG']);
+    TreatmentRecord::create([
+        'service_order_id' => $serviceOrder->id,
+        'department_id' => $serviceOrder->service->service_department_id,
+        'treating_doctor_id' => User::factory()->create()->id,
+        'recorded_by' => User::factory()->create()->id,
+        'treated_at' => now(),
+        'prescriptions' => [
+            ['drug_name' => 'Aspirin', 'dose' => '300mg'],
+            ['drug_name' => 'Morphine', 'dose' => '2mg'],
+        ],
+    ]);
+
+    $html = view('pdfs.serviceorder', ['serviceOrder' => $serviceOrder->fresh(['patient', 'doctor', 'treatmentRecord']), 'patient' => $serviceOrder->patient])->render();
+
+    // 1 header row + 2 prescription rows + 1 trailing blank row.
+    expect(rowCountBetween($html, '<table class="drug-table">', '</table>'))->toBe(4);
+});
+
+test('treatment given section keeps a full set of blank writing lines when no treatment is recorded yet', function () {
+    $serviceOrder = ServiceOrder::factory()->create(['type' => 'EMG']);
+
+    $html = view('pdfs.serviceorder', ['serviceOrder' => $serviceOrder->fresh(['patient', 'doctor']), 'patient' => $serviceOrder->patient])->render();
+
+    // 7 blank alignment rows (marker sits inside the header row, so it's excluded).
+    expect(rowCountBetween($html, 'TREATMENT GIVEN:', '</table>'))->toBe(7);
+});
+
+test('treatment given section only pads with one blank row once a treatment plan is recorded', function () {
+    $serviceOrder = ServiceOrder::factory()->create(['type' => 'EMG']);
+    TreatmentRecord::create([
+        'service_order_id' => $serviceOrder->id,
+        'department_id' => $serviceOrder->service->service_department_id,
+        'treating_doctor_id' => User::factory()->create()->id,
+        'recorded_by' => User::factory()->create()->id,
+        'treated_at' => now(),
+        'treatment_plan' => 'Aspirin, oxygen, cardiology referral',
+    ]);
+
+    $html = view('pdfs.serviceorder', ['serviceOrder' => $serviceOrder->fresh(['patient', 'doctor', 'treatmentRecord']), 'patient' => $serviceOrder->patient])->render();
+
+    // 1 content row + 1 trailing blank row (marker sits inside the header row, so it's excluded).
+    expect(rowCountBetween($html, 'TREATMENT GIVEN:', '</table>'))->toBe(2);
+});


### PR DESCRIPTION
## Summary
- **Department search prefill**: OPD, EMG, IND, DNT, LAB, ULT, and XRAY dashboards now pre-fill their search box with the department's current `so_short` prefix (e.g. `EMG/0000133`) and auto-run that search on load, so staff only type the digit(s) that differ instead of seeing an empty list. Added `so_short`-prefix matching and raised the result cap to 20 across the three search endpoints (`Api\OpdController`, `Api\IndController`, `Api\DepartmentController`) that previously only matched full/exact numbers.
- **EMG triage picker**: replaced the Triage Level `<select>` dropdown with colored radio pills (one per triage level, tinted to its color) so the doctor clicks directly instead of opening a dropdown. The Code Black confirmation dialog still fires correctly.
- **Service Order PDF padding**: the TREATMENT GIVEN and drug chart sections now only add one trailing blank row once real content exists, instead of always padding out to a fixed minimum (7 / 5 rows). A still-blank form keeps its full set of writing lines for alignment.

## Test plan
- [x] `php artisan test --compact` — 639 passed, 1 pre-existing unrelated failure (`AbacusClosingIntegrationTest`, confirmed failing on `main` before this branch too)
- [x] New tests: 6 for search prefix/prefill behavior, 4 for PDF row padding (blank-vs-populated for both sections)
- [x] `vendor/bin/pint --dirty` clean
- [x] `eslint` / `tsc` clean on all touched frontend files (no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)