### PR TITLE
feat: add configurable 1-page compact emergency triage print template

### DIFF
--- a/app/Enum/ServiceOrderTemplate.php
+++ b/app/Enum/ServiceOrderTemplate.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Enum;
+
+enum ServiceOrderTemplate: string
+{
+    case EmergencyTriageDetailed = 'emergency_triage_detailed';
+    case EmergencyTriageCompact = 'emergency_triage_compact';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::EmergencyTriageDetailed => 'Emergency Triage - Detailed (2 Page)',
+            self::EmergencyTriageCompact => 'Emergency Triage - Compact (1 Page)',
+        };
+    }
+
+    public function view(): string
+    {
+        return match ($this) {
+            self::EmergencyTriageDetailed => 'pdfs.serviceorder',
+            self::EmergencyTriageCompact => 'pdfs.serviceorder-triage-compact',
+        };
+    }
+
+    public static function default(): self
+    {
+        return self::EmergencyTriageDetailed;
+    }
+}

--- a/app/Filament/Admin/Resources/ServiceDepartments/ServiceDepartmentResource.php
+++ b/app/Filament/Admin/Resources/ServiceDepartments/ServiceDepartmentResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Admin\Resources\ServiceDepartments;
 
+use App\Enum\ServiceOrderTemplate;
 use App\Filament\Admin\Resources\ServiceDepartments\Pages\ManageServiceDepartments;
 use App\Models\ServiceDepartment;
 use BackedEnum;
@@ -10,6 +11,7 @@ use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Forms\Components\FileUpload;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
@@ -44,6 +46,14 @@ class ServiceDepartmentResource extends Resource
                 TextInput::make('have_composit_services')
                     ->required()
                     ->numeric(),
+                Select::make('service_order_template')
+                    ->label('Service Order Print Template')
+                    ->helperText('Template used when staff print a service order for this department. Leave empty to use the default detailed template.')
+                    ->native(false)
+                    ->options(collect(ServiceOrderTemplate::cases())
+                        ->mapWithKeys(fn (ServiceOrderTemplate $template) => [$template->value => $template->label()])
+                        ->toArray())
+                    ->placeholder('Default ('.ServiceOrderTemplate::default()->label().')'),
             ]);
     }
 
@@ -70,6 +80,10 @@ class ServiceDepartmentResource extends Resource
                 TextColumn::make('have_composit_services')
                     ->numeric()
                     ->sortable(),
+                TextColumn::make('service_order_template')
+                    ->label('Print Template')
+                    ->formatStateUsing(fn (?ServiceOrderTemplate $state) => $state?->label() ?? 'Default ('.ServiceOrderTemplate::default()->label().')')
+                    ->badge(),
                 TextColumn::make('created_at')
                     ->dateTime()
                     ->sortable()

--- a/app/Http/Controllers/Prints/ServiceOrderPdfPrintController.php
+++ b/app/Http/Controllers/Prints/ServiceOrderPdfPrintController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Prints;
 
+use App\Enum\ServiceOrderTemplate;
 use App\Http\Controllers\Controller;
 use App\Models\ServiceOrder;
 use App\Models\TreatmentRecord;
@@ -19,7 +20,7 @@ class ServiceOrderPdfPrintController extends Controller
         $serviceOrder = ServiceOrder::with([
             'patient',
             'doctor',
-            'service.department:id,name',
+            'service.department:id,name,service_order_template',
             'treatmentRecord.triage',
             'treatmentRecord.attachments',
             'treatmentRecord.treatingDoctor',
@@ -39,7 +40,9 @@ class ServiceOrderPdfPrintController extends Controller
             ->limit(6)
             ->get(['id', 'service_order_id', 'diagnosis_code', 'icd10_code_id', 'treated_at']);
 
-        $html = view('pdfs.serviceorder', [
+        $template = $serviceOrder->service?->department?->service_order_template ?? ServiceOrderTemplate::default();
+
+        $html = view($template->view(), [
             'serviceOrder' => $serviceOrder,
             'patient' => $patient,
             'pastDiagnoses' => $pastDiagnoses,

--- a/app/Models/ServiceDepartment.php
+++ b/app/Models/ServiceDepartment.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enum\ServiceOrderTemplate;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -16,10 +17,12 @@ class ServiceDepartment extends Model
         'slug',
         'image',
         'have_composit_services',
+        'service_order_template',
     ];
 
     protected $casts = [
         'have_composit_services' => 'boolean',
+        'service_order_template' => ServiceOrderTemplate::class,
     ];
 
     public function services()

--- a/database/migrations/2026_08_10_162913_add_service_order_template_to_service_departments_table.php
+++ b/database/migrations/2026_08_10_162913_add_service_order_template_to_service_departments_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('service_departments', function (Blueprint $table) {
+            $table->string('service_order_template')->nullable()->after('have_composit_services');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('service_departments', function (Blueprint $table) {
+            $table->dropColumn('service_order_template');
+        });
+    }
+};

--- a/docs/fixes/README.md
+++ b/docs/fixes/README.md
@@ -18,3 +18,4 @@ Each fix is documented from four perspectives so every stakeholder has the infor
 | 1 | [#3](https://github.com/afaryab/hospital-care/issues/3) | Race condition in CT and SO number generation | High | ✅ Fixed |
 | 2 | [#4](https://github.com/afaryab/hospital-care/issues/4) | Missing authorization — resource-level access control | Critical | ✅ Fixed |
 | 3 | [#5](https://github.com/afaryab/hospital-care/issues/5) | CNIC patient search uses wrong variable | High | ✅ Fixed |
+| 4 | [#34](https://github.com/afaryab/hospital-care/issues/34) | Configurable 1-page compact emergency triage print template | Enhancement | ✅ Implemented (PR #35) |

--- a/docs/fixes/fix-004-configurable-emergency-triage-print-template.md
+++ b/docs/fixes/fix-004-configurable-emergency-triage-print-template.md
@@ -1,0 +1,124 @@
+# Fix #004 — Configurable 1-Page Compact Emergency Triage Print Template
+
+**GitHub Issue:** [afaryab/hospital-care#34](https://github.com/afaryab/hospital-care/issues/34)
+**Severity:** Enhancement (P2)
+**Status:** ✅ Implemented — pending review/merge ([PR #35](https://github.com/afaryab/hospital-care/pull/35))
+**Branch:** `feature/service-order-print-templates`
+**Date:** 2026-08-10
+
+---
+
+## For Developers
+
+### What was added
+
+Previously `ServiceOrderPdfPrintController::stream()` rendered `pdfs.serviceorder` (the 2-page "ED Clinical Performa") unconditionally for every service order, regardless of department — there was no mechanism mapping a department to a print template.
+
+This adds:
+
+1. `app/Enum/ServiceOrderTemplate.php` — string-backed enum with `EmergencyTriageDetailed` (existing 2-page, default) and `EmergencyTriageCompact` (new 1-page), each exposing `label()` and `view()`.
+2. `service_order_template` nullable column on `service_departments`, cast to the enum on `ServiceDepartment`.
+3. `resources/views/pdfs/serviceorder-triage-compact.blade.php` — a condensed single-page layout: patient info, triage note, one consent block (vs. two bilingual duplicates), vitals, exam findings, treatment/investigation, a shorter drug chart, diagnosis + disposition checkboxes, signatures.
+4. `ServiceOrderPdfPrintController` resolves `$serviceOrder->service->department->service_order_template`, falling back to `ServiceOrderTemplate::default()` (the detailed template) when unset — existing departments keep their current behavior unless explicitly reconfigured.
+5. Filament `ServiceDepartmentResource` form gets a "Service Order Print Template" `Select` (nullable, placeholder shows the default); the table gets a matching badge column.
+
+```php
+$template = $serviceOrder->service?->department?->service_order_template ?? ServiceOrderTemplate::default();
+
+$html = view($template->view(), [...])->render();
+```
+
+### Files changed
+
+- `app/Enum/ServiceOrderTemplate.php` (new)
+- `database/migrations/2026_08_10_162913_add_service_order_template_to_service_departments_table.php` (new)
+- `resources/views/pdfs/serviceorder-triage-compact.blade.php` (new)
+- `app/Models/ServiceDepartment.php` — fillable + cast
+- `app/Http/Controllers/Prints/ServiceOrderPdfPrintController.php` — template resolution
+- `app/Filament/Admin/Resources/ServiceDepartments/ServiceDepartmentResource.php` — form select + table badge
+- `tests/Feature/Filament/Admin/ServiceDepartmentResourceTest.php` (new)
+- `tests/Feature/Models/ServiceDepartmentModelTest.php`, `tests/Feature/Prints/ServiceOrderPdfPrintTest.php` — extended
+
+### Tests
+
+```bash
+php artisan test --compact tests/Feature/Prints/ServiceOrderPdfPrintTest.php tests/Feature/Models/ServiceDepartmentModelTest.php tests/Feature/Filament/Admin/ServiceDepartmentResourceTest.php
+```
+
+27 tests / 80 assertions, all passing. Full suite run: 650 passed, 1 skipped, 1 failed — the failure (`AbacusClosingIntegrationTest`) was confirmed pre-existing on `main` (unrelated `app:sync-old-hims` exit-code assertion), not introduced by this change.
+
+New coverage:
+- Model casts `service_order_template` to the enum; defaults to `null`
+- Controller renders the detailed view when no template is configured, and the compact view when `EmergencyTriageCompact` is set (verified via `Pdf::shouldReceive('loadHTML')` argument assertions, since dompdf's binary output can't be inspected for text)
+- Compact template content fidelity (patient info, triage category, prescriptions, real department name, disposition checkboxes)
+- Filament create action persists the selected template; leaves it `null` when not chosen
+
+### Manual verification
+
+Rendered both templates through dompdf with realistic data (patient, triage, vitals, 2 prescriptions, discharge outcome) and inspected the PDF's `/Count` page-tree value directly: compact template = **1 page**, detailed template = **2 pages**.
+
+### Known limitations / out of scope
+
+- Only two template options exist today (detailed, compact). The enum is the extension point for future department-specific templates (e.g. dedicated OPD/Dental layouts) — the `TransactionPdfPrintController` `variant`-param pattern is a precedent if a request-time override (vs. department default) is ever needed.
+- The print route/filename (`ED-Clinical-Performa-*.pdf`) is unchanged and still generic across departments — not in scope for this change.
+
+---
+
+## For IT / DevOps
+
+### What changed on the server
+
+One new migration adds a nullable `service_order_template` (VARCHAR) column to `service_departments`. No data backfill needed — existing rows default to `NULL`, which the app treats as "use the detailed template" (identical to current behavior).
+
+### Deployment steps
+
+1. Pull latest code
+2. `docker compose up --build` (or standard deploy)
+3. `php artisan migrate` — adds the new column
+4. No queue/cache changes required
+
+### How to verify after deploy
+
+1. In `/admin` → Services → Service Departments, edit a department and confirm the "Service Order Print Template" select appears with two options plus a "Default" placeholder.
+2. Set a department to "Emergency Triage - Compact (1 Page)", print a service order for that department, and confirm the PDF is one page.
+3. Confirm a department left unconfigured still produces the original 2-page PDF.
+
+### Rollback
+
+`php artisan migrate:rollback` reverts the column (only if this migration is the most recent). Revert the code changes via git as normal — no destructive data changes are involved since the column is purely additive and nullable.
+
+### Risk
+
+**Low.** Additive, nullable column; default behavior (no template configured) is byte-for-byte the same code path as before this change. Only departments an admin explicitly reconfigures will see different print output.
+
+---
+
+## For Reception Staff
+
+### What changed?
+
+Nothing changes for existing departments unless an administrator configures otherwise. If your department is switched to the new "Compact" template, printed service order forms will now be **one page instead of two**, with the same core information (patient details, triage note, vitals, treatment, prescriptions, discharge disposition) laid out more tightly.
+
+### When will you notice the difference?
+
+Only after an administrator changes a department's print template setting in the admin panel. Ask your administrator which departments have been switched if you're unsure which layout to expect.
+
+---
+
+## For Hospital Administration
+
+### Business impact
+
+| Scenario | Before | After |
+|---|---|---|
+| Printing emergency/triage service orders | Always 2 pages per order, regardless of department | Configurable per department — compact 1-page option available |
+| Paper/toner cost for high-volume departments | Fixed at 2 pages/order | Reducible to 1 page/order where the compact template is selected |
+| Existing workflows | N/A | Unaffected unless an admin opts in per department |
+
+### Compliance relevance
+
+The compact template retains all PHC/HIPAA-relevant structured fields (patient demographics, triage time/category, vitals, diagnosis, prescriptions with prescriber and time, disposition/outcome, doctor signature) — it drops only redundant elements (duplicate bilingual consent boxes, extended review/follow-up scheduling rows) that aren't part of the minimum structured record. No clinical or identifying data is omitted.
+
+### Data impact
+
+No patient data is affected. This is a presentation/print-layout change only, controlled by a new per-department setting.

--- a/resources/views/pdfs/serviceorder-triage-compact.blade.php
+++ b/resources/views/pdfs/serviceorder-triage-compact.blade.php
@@ -1,0 +1,328 @@
+@php
+    $hospitalName = \App\Models\HospitalSetting::get('hospital_name', config('app.name'));
+    $departmentName = $serviceOrder->service?->department?->name ?? 'Emergency';
+    $tr = $serviceOrder->treatmentRecord;
+    $lastVital = $tr?->vitalSigns?->last();
+    $treatingDoctor = $tr?->treatingDoctor ?? $serviceOrder->doctor;
+    $treatingDoctorName = $treatingDoctor?->name ?? '';
+    if ($treatingDoctor?->pmdc_number) {
+        $treatingDoctorName .= " (PMDC# {$treatingDoctor->pmdc_number})";
+    }
+    $prescriptions = $tr?->prescriptions ?? [];
+    // Compact chart keeps far fewer blank alignment rows than the detailed
+    // template since the whole point of this variant is fitting one page.
+    $drugRowCount = count($prescriptions) > 0 ? count($prescriptions) + 1 : 3;
+    $outcomeValue = $tr?->outcome?->value;
+    $checked = fn (string $value) => $outcomeValue === $value ? 'X' : '';
+@endphp
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Emergency Department - Triage Note (Compact)</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+
+    <style>
+        *{ box-sizing:border-box; }
+        body{
+            margin:0;
+            font-family: Arial, Helvetica, sans-serif;
+            color:#111;
+            font-size: 10.5px;
+        }
+
+        .page{
+            width: 100%;
+            background:#fff;
+            margin: 0 auto;
+        }
+
+        @media print{
+            body{ background:#fff; }
+            .page{ margin:0; border:0;}
+        }
+
+        .center{ text-align:center; }
+        .bold{ font-weight:700; }
+        .u{ text-decoration: underline; }
+
+        .heading-wrap{
+            text-align:center;
+            margin-top:4px;
+        }
+        .heading-wrap > *{ display:block; margin: 3px auto; }
+        .badge{
+            display:inline-block;
+            padding:2px 12px;
+            background:#111;
+            color:#fff;
+            font-weight:700;
+            letter-spacing:.5px;
+            font-size: 13px;
+        }
+        .subhead{
+            font-weight:700;
+            letter-spacing:.5px;
+            font-size: 12px;
+        }
+
+        .kv-table{ width:100%; border-collapse:collapse; table-layout: fixed; }
+        .kv-table td{ border:0; padding: 1px 4px; vertical-align:middle; }
+        .kv-label{ white-space:nowrap; font-weight:700; border-bottom: 1px dotted #222 !important; height: 14px; }
+        .kv-line{ border-bottom: 1px dotted #222 !important; height: 14px; }
+        .w-mid{ width: 180px; }
+        .w-long{ width: 100%; }
+
+        .section-title{
+            font-weight:800;
+            margin: 4px 0 2px 0;
+            font-size: 11px;
+        }
+
+        .triage-note{
+            text-decoration: underline;
+            font-weight: 700;
+        }
+
+        .checkbox{
+            display:inline-block;
+            width: 10px;
+            height: 10px;
+            border: 1px solid #222;
+            vertical-align:middle;
+            margin-right:5px;
+        }
+
+        table{
+            width:100%;
+            border-collapse:collapse;
+            font-size: 10.5px;
+        }
+        td, th{
+            border: 1px solid #222;
+            padding: 3px 5px;
+            vertical-align:top;
+        }
+        th{ font-weight:800; text-align:left; }
+
+        .bg-gray{ background-color: #ebebeb; }
+
+        .clinical-grid td{ height: 14px; }
+
+        .drug-table th, .drug-table td{ font-size: 10px; }
+        .drug-table td{ height: 14px; }
+
+        .inline-check{
+            display:inline-flex;
+            align-items:center;
+            gap:4px;
+            margin-right:12px;
+            white-space:nowrap;
+            font-size: 10px;
+        }
+        .cb{
+            width: 10px;
+            height: 10px;
+            border: 1px solid #222;
+            display:inline-block;
+        }
+
+        .vitals-row{
+            border: 1px solid #222;
+            padding: 4px 6px;
+            margin-top: 4px;
+        }
+
+        .no-border td{ border:0 !important; padding: 2px 0; }
+    </style>
+</head>
+<body>
+    <div class="page">
+
+        <div class="heading-wrap">
+            <div class="badge">{{ strtoupper($departmentName) }} DEPARTMENT</div>
+            <div class="subhead">TRIAGE NOTE SO: <span class="u">{{ $serviceOrder->so_number ?? '' }}{{ $serviceOrder->so_short ? ' ('.$serviceOrder->so_short.')' : '' }}</span> &mdash; 1 Page</div>
+        </div>
+
+        {{-- Patient + Triage --}}
+        <table style="width:100%; margin-top:6px; border-collapse:collapse;">
+            <tr>
+                <td style="width:50%; vertical-align:top; padding-right:6px; border:0;">
+                    <table class="kv-table">
+                        <tr>
+                            <td class="kv-label" style="width:26%;">MR # :</td>
+                            <td class="kv-line w-mid" style="width:74%;">{{ $serviceOrder->so_number ?? '' }}{{ $serviceOrder->so_short ? ' ('.$serviceOrder->so_short.')' : '' }}</td>
+                        </tr>
+                        <tr>
+                            <td class="kv-label">Date:</td>
+                            <td class="kv-line w-mid"> @hdate($serviceOrder->created_at, 'd-m-Y H:i')</td>
+                        </tr>
+                        <tr>
+                            <td class="kv-label">Pt. Name:</td>
+                            <td class="kv-line w-long">{{ $patient->name ?? '' }}</td>
+                        </tr>
+                        <tr>
+                            <td class="kv-label">S/o, D/o, W/o:</td>
+                            <td class="kv-line w-long">{{ trim(($patient->relation ?? '').' '.($patient->guardian ?? '')) }}</td>
+                        </tr>
+                        <tr>
+                            <td class="kv-label">Age &amp; Sex:</td>
+                            <td class="kv-line w-long">{{ $patient->age ?? '' }} / {{ $patient->gender ?? '' }}</td>
+                        </tr>
+                    </table>
+                </td>
+                <td style="width:50%; vertical-align:top; border:0;">
+                    <table class="kv-table">
+                        <tr>
+                            <td colspan="2" class="triage-note">Triage Note</td>
+                        </tr>
+                        <tr>
+                            <td class="kv-label" style="width: 26%;">Time:</td>
+                            <td class="kv-line w-mid" style="width: 74%;">@hdate($tr?->treated_at, 'd-m-Y H:i')</td>
+                        </tr>
+                        <tr>
+                            <td class="kv-label">Doctor:</td>
+                            <td class="kv-line w-long">{{ $treatingDoctorName }}</td>
+                        </tr>
+                        <tr>
+                            <td class="kv-label">Triage Category:</td>
+                            <td class="kv-line w-long">{{ $tr?->triage?->name }}</td>
+                        </tr>
+                        <tr>
+                            <td class="kv-label">Complain:</td>
+                            <td class="kv-line w-long">{{ $tr?->chief_complaint }}</td>
+                        </tr>
+                    </table>
+                </td>
+            </tr>
+        </table>
+
+        {{-- Consent (single, compact) --}}
+        <div class="vitals-row">
+            <span class="checkbox"></span>
+            <span>We give our consent according to the patient&rsquo;s condition. In case of any medication-related issue or loss of life, {{ $hospitalName }} will not be held responsible.</span>
+            <table class="kv-table" style="margin-top:3px;">
+                <tr>
+                    <td class="kv-label" style="width:10%;">Signature:</td>
+                    <td class="kv-line" style="width:40%;"></td>
+                    <td class="kv-label" style="width:10%;">Relation:</td>
+                    <td class="kv-line" style="width:40%;"></td>
+                </tr>
+            </table>
+        </div>
+
+        {{-- History + Vitals --}}
+        <table class="clinical-grid" style="margin-top:4px;">
+            <tr>
+                <td class="bold" style="width:50%;">HISTORY OF PRESENT ILLNESS:</td>
+                <td class="bold" style="width:50%;">EXAMINATION / VITALS:</td>
+            </tr>
+            <tr>
+                <td>{{ $tr?->history_of_present_illness }}</td>
+                <td>
+                    Airway: Clear Y/N &nbsp; Breathing: Spontaneous Y/N<br>
+                    R/R: {{ $lastVital?->respiratory_rate }} /min &nbsp; Pulse: {{ $lastVital?->pulse_rate }} /min<br>
+                    BP: {{ $lastVital && $lastVital->blood_pressure_systolic ? $lastVital->blood_pressure_systolic.'/'.$lastVital->blood_pressure_diastolic : '' }} &nbsp; Temp: {{ $lastVital?->temperature }} F &nbsp; GCS: &nbsp; BSL:
+                </td>
+            </tr>
+            <tr>
+                <td class="bold">
+                    @php $examFindings = $tr?->examination_findings ?? []; @endphp
+                    @foreach($examFindings as $label => $value)
+                        {{ $label }}: {{ $value }}<br>
+                    @endforeach
+                </td>
+                <td>
+                    <span class="inline-check"><span class="cb"></span> Allergies</span>
+                    <span class="inline-check"><span class="cb"></span> Immunization</span>
+                    <span class="inline-check"><span class="cb"></span> Smoker</span>
+                    <span class="inline-check"><span class="cb"></span> Medications</span>
+                </td>
+            </tr>
+        </table>
+
+        {{-- Treatment / Investigation --}}
+        <table class="clinical-grid" style="margin-top:4px;">
+            <tr>
+                <td class="bold" style="width:60%;">TREATMENT GIVEN:</td>
+                <td class="bold" style="width:40%;">INVESTIGATION DONE:</td>
+            </tr>
+            <tr>
+                <td style="height:24px;">{{ $tr?->treatment_plan }}</td>
+                <td style="height:24px;"></td>
+            </tr>
+        </table>
+
+        {{-- Drug chart --}}
+        <table class="drug-table" style="margin-top:4px;">
+            <tr>
+                <th class="bold bg-gray" style="width:12%;">DATE</th>
+                <th class="bold bg-gray" style="width:40%;">DRUG / DOSE / ROUTE</th>
+                <th class="bold bg-gray" style="width:24%;">PRESCRIBED BY</th>
+                <th class="bold bg-gray" style="width:12%;">TIME</th>
+                <th class="bold bg-gray" style="width:12%;">SIGN</th>
+            </tr>
+
+            @for($i=0; $i<$drugRowCount; $i++)
+                @php
+                    $rx = $prescriptions[$i] ?? null;
+                    $rxTime = $rx['given_at'] ?? $tr?->treated_at;
+                @endphp
+                <tr>
+                    <td>{{ $rx ? \App\Helpers\DateHelper::pdfFormat($rxTime, 'd-m-Y') : '' }}</td>
+                    <td>
+                        @if($rx)
+                            {{ trim(($rx['drug_name'] ?? '').' '.($rx['dose'] ?? '').' '.($rx['frequency'] ?? '').' '.($rx['route'] ?? '')) }}
+                        @endif
+                    </td>
+                    <td>{{ $rx ? $treatingDoctorName : '' }}</td>
+                    <td>{{ $rx ? \App\Helpers\DateHelper::pdfFormat($rxTime, 'H:i') : '' }}</td>
+                    <td></td>
+                </tr>
+            @endfor
+        </table>
+
+        {{-- Diagnosis + Disposition --}}
+        <table class="clinical-grid" style="margin-top:4px;">
+            <tr>
+                <th class="bold bg-gray">DISCHARGE DIAGNOSIS</th>
+            </tr>
+            <tr>
+                <td>{{ trim(($tr?->diagnosis_code ?? '').' '.($tr?->diagnosis_text ?? '')) }}</td>
+            </tr>
+        </table>
+
+        <div class="vitals-row" style="margin-top:4px;">
+            <span class="inline-check"><span class="cb">{{ $checked('discharged') }}</span> DISCHARGED HOME &nbsp;{{ $outcomeValue === 'discharged' ? '('.\App\Helpers\DateHelper::pdfFormat($tr?->outcome_at, 'd-m-Y H:i').')' : '' }}</span>
+            <span class="inline-check"><span class="cb">{{ $checked('referred') }}</span> REFERRED / TRANSFERRED TO: {{ $outcomeValue === 'referred' ? $tr?->referral_to : '' }}</span>
+            <span class="inline-check"><span class="cb"></span> ADMITTED TO:&nbsp;</span>
+            <span class="inline-check"><span class="cb">{{ $checked('expired') }}</span> DIED IN ED &nbsp;{{ $outcomeValue === 'expired' ? '('.\App\Helpers\DateHelper::pdfFormat($tr?->outcome_at, 'd-m-Y H:i').')' : '' }}</span>
+            <span class="inline-check"><span class="cb"></span> LEFT AGAINST MEDICAL ADVICE</span>
+            <div style="margin-top:3px;">{{ $tr?->outcome_notes }}</div>
+        </div>
+
+        {{-- Signatures --}}
+        <table class="no-border" style="margin-top:8px;">
+            <tr>
+                <td style="width:50%;">
+                    <table class="kv-table">
+                        <tr>
+                            <td class="kv-label" style="width:40%;">Discharging Doctor:</td>
+                            <td class="kv-line w-long">{{ $treatingDoctorName }}</td>
+                        </tr>
+                    </table>
+                </td>
+                <td style="width:50%;">
+                    <table class="kv-table">
+                        <tr>
+                            <td class="kv-label" style="width:30%;">Nurse Sign:</td>
+                            <td class="kv-line w-long"></td>
+                        </tr>
+                    </table>
+                </td>
+            </tr>
+        </table>
+    </div>
+</body>
+</html>

--- a/tests/Feature/Filament/Admin/ServiceDepartmentResourceTest.php
+++ b/tests/Feature/Filament/Admin/ServiceDepartmentResourceTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use App\Enum\ServiceOrderTemplate;
+use App\Filament\Admin\Resources\ServiceDepartments\Pages\ManageServiceDepartments;
+use App\Models\Administrator;
+use App\Models\ServiceDepartment;
+use App\Models\User;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+
+use function Pest\Laravel\assertDatabaseHas;
+
+beforeEach(function () {
+    Storage::fake('public');
+    $this->user = User::factory()->create();
+    Administrator::create(['user_id' => $this->user->id, 'authority' => 'administrator']);
+    $this->actingAs($this->user);
+});
+
+test('service department manage page renders', function () {
+    Livewire\Livewire::test(ManageServiceDepartments::class)->assertSuccessful();
+});
+
+test('service department manage page shows the configured print template', function () {
+    $departments = ServiceDepartment::factory()->count(2)->create();
+
+    Livewire\Livewire::test(ManageServiceDepartments::class)->assertCanSeeTableRecords($departments);
+});
+
+test('admin can create a service department with a print template', function () {
+    Livewire\Livewire::test(ManageServiceDepartments::class)
+        ->callAction('create', data: [
+            'name' => 'Emergency',
+            'slug' => 'EMG-2',
+            'image' => UploadedFile::fake()->image('emergency.jpg'),
+            'have_composit_services' => 0,
+            'service_order_template' => ServiceOrderTemplate::EmergencyTriageCompact->value,
+        ])
+        ->assertNotified();
+
+    assertDatabaseHas(ServiceDepartment::class, [
+        'name' => 'Emergency',
+        'service_order_template' => ServiceOrderTemplate::EmergencyTriageCompact->value,
+    ]);
+});
+
+test('service department print template is left unset when not chosen', function () {
+    Livewire\Livewire::test(ManageServiceDepartments::class)
+        ->callAction('create', data: [
+            'name' => 'Ultrasound',
+            'slug' => 'ULT-2',
+            'image' => UploadedFile::fake()->image('ultrasound.jpg'),
+            'have_composit_services' => 0,
+        ])
+        ->assertNotified();
+
+    assertDatabaseHas(ServiceDepartment::class, [
+        'name' => 'Ultrasound',
+        'service_order_template' => null,
+    ]);
+});

--- a/tests/Feature/Models/ServiceDepartmentModelTest.php
+++ b/tests/Feature/Models/ServiceDepartmentModelTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enum\ServiceOrderTemplate;
 use App\Models\ServiceDepartment;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
@@ -19,4 +20,18 @@ test('service department casts have_composit_services to boolean', function () {
     $department = ServiceDepartment::factory()->create(['have_composit_services' => true]);
 
     expect($department->have_composit_services)->toBeTrue();
+});
+
+test('service department has no print template configured by default', function () {
+    $department = ServiceDepartment::factory()->create();
+
+    expect($department->service_order_template)->toBeNull();
+});
+
+test('service department casts service_order_template to the enum', function () {
+    $department = ServiceDepartment::factory()->create([
+        'service_order_template' => ServiceOrderTemplate::EmergencyTriageCompact,
+    ]);
+
+    expect($department->fresh()->service_order_template)->toBe(ServiceOrderTemplate::EmergencyTriageCompact);
 });

--- a/tests/Feature/Prints/ServiceOrderPdfPrintTest.php
+++ b/tests/Feature/Prints/ServiceOrderPdfPrintTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enum\ServiceOrderTemplate;
 use App\Helpers\DateHelper;
 use App\Models\EmergencyDoctor;
 use App\Models\Patient;
@@ -10,6 +11,7 @@ use App\Models\TreatmentRecord;
 use App\Models\Triage;
 use App\Models\User;
 use App\Models\VitalSign;
+use Barryvdh\DomPDF\Facade\Pdf;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\get;
@@ -171,6 +173,111 @@ test('the PDF shows the service order\'s real department name, not a hardcoded o
 
     expect($html)->toContain('DENTAL DEPARTMENT')
         ->not->toContain('EMERGENCY DEPARTMENT');
+});
+
+test('the pdf falls back to the detailed 2-page template when the department has no print template configured', function () {
+    actingAs(User::factory()->create());
+
+    $department = ServiceDepartment::factory()->create(['service_order_template' => null]);
+    $service = Service::factory()->create(['service_department_id' => $department->id]);
+    $serviceOrder = ServiceOrder::factory()->create(['type' => 'EMG', 'service_id' => $service->id]);
+
+    Pdf::shouldReceive('loadHTML')
+        ->once()
+        ->withArgs(fn (string $html) => str_contains($html, 'Page 1/2') && str_contains($html, 'CLINICAL PERFORMA SO'))
+        ->andReturnSelf();
+    Pdf::shouldReceive('setPaper')->once()->with('A4')->andReturnSelf();
+    Pdf::shouldReceive('stream')->once()->andReturn(response('%PDF-1.4 fake', 200, ['Content-Type' => 'application/pdf']));
+
+    get(route('print-serviceorder', ['id' => $serviceOrder->id]))->assertOk();
+});
+
+test('the pdf uses the compact 1-page template when configured on the department', function () {
+    actingAs(User::factory()->create());
+
+    $department = ServiceDepartment::factory()->create([
+        'service_order_template' => ServiceOrderTemplate::EmergencyTriageCompact,
+    ]);
+    $service = Service::factory()->create(['service_department_id' => $department->id]);
+    $serviceOrder = ServiceOrder::factory()->create(['type' => 'EMG', 'service_id' => $service->id]);
+
+    Pdf::shouldReceive('loadHTML')
+        ->once()
+        ->withArgs(fn (string $html) => str_contains($html, 'TRIAGE NOTE SO') && ! str_contains($html, 'Page 1/2'))
+        ->andReturnSelf();
+    Pdf::shouldReceive('setPaper')->once()->with('A4')->andReturnSelf();
+    Pdf::shouldReceive('stream')->once()->andReturn(response('%PDF-1.4 fake', 200, ['Content-Type' => 'application/pdf']));
+
+    get(route('print-serviceorder', ['id' => $serviceOrder->id]))->assertOk();
+});
+
+test('the compact triage pdf includes patient info, triage category, and prescriptions', function () {
+    $patient = Patient::factory()->create(['guardian' => 'Muhammad Ali', 'relation' => 'S/o']);
+    $doctor = User::factory()->create(['name' => 'Dr. Sara Ahmed']);
+    $serviceOrder = ServiceOrder::factory()->create([
+        'type' => 'EMG',
+        'patient_id' => $patient->id,
+        'doctor_id' => $doctor->id,
+    ]);
+    $triage = Triage::factory()->create(['name' => 'Priority Custom']);
+
+    TreatmentRecord::create([
+        'service_order_id' => $serviceOrder->id,
+        'department_id' => $serviceOrder->service->service_department_id,
+        'treating_doctor_id' => $doctor->id,
+        'recorded_by' => $doctor->id,
+        'treated_at' => now(),
+        'chief_complaint' => 'Severe chest pain radiating to left arm',
+        'triage_id' => $triage->id,
+        'prescriptions' => [
+            ['drug_name' => 'Aspirin', 'dose' => '300mg', 'frequency' => 'stat', 'route' => 'PO'],
+        ],
+    ]);
+
+    $serviceOrder = $serviceOrder->fresh([
+        'patient', 'doctor', 'treatmentRecord.triage', 'treatmentRecord.treatingDoctor', 'treatmentRecord.vitalSigns',
+    ]);
+
+    $html = view('pdfs.serviceorder-triage-compact', ['serviceOrder' => $serviceOrder, 'patient' => $serviceOrder->patient])->render();
+
+    expect($html)->toContain('Severe chest pain radiating to left arm')
+        ->toContain('Priority Custom')
+        ->toContain('S/o Muhammad Ali')
+        ->toContain('Aspirin 300mg stat PO')
+        ->not->toContain('Page 1/2');
+});
+
+test('the compact triage pdf shows the real department name, not a hardcoded one', function () {
+    $department = ServiceDepartment::factory()->create(['name' => 'Dental']);
+    $service = Service::factory()->create(['service_department_id' => $department->id]);
+    $serviceOrder = ServiceOrder::factory()->create(['type' => 'DNT', 'service_id' => $service->id]);
+
+    $serviceOrder = $serviceOrder->fresh(['patient', 'doctor', 'service.department']);
+    $html = view('pdfs.serviceorder-triage-compact', ['serviceOrder' => $serviceOrder, 'patient' => $serviceOrder->patient])->render();
+
+    expect($html)->toContain('DENTAL DEPARTMENT')
+        ->not->toContain('EMERGENCY DEPARTMENT');
+});
+
+test('the compact triage pdf ticks the referred disposition checkbox', function () {
+    $serviceOrder = ServiceOrder::factory()->create(['type' => 'EMG']);
+    TreatmentRecord::create([
+        'service_order_id' => $serviceOrder->id,
+        'department_id' => $serviceOrder->service->service_department_id,
+        'treating_doctor_id' => User::factory()->create()->id,
+        'recorded_by' => User::factory()->create()->id,
+        'treated_at' => now(),
+        'outcome' => 'referred',
+        'outcome_at' => '2026-07-27 16:00:00',
+        'referral_to' => 'City General Hospital',
+    ]);
+
+    $html = view('pdfs.serviceorder-triage-compact', ['serviceOrder' => $serviceOrder->fresh(['patient', 'doctor', 'treatmentRecord.treatingDoctor', 'treatmentRecord.vitalSigns']), 'patient' => $serviceOrder->patient])->render();
+
+    expect($html)->toContain('<span class="cb">X</span> REFERRED')
+        ->toContain('City General Hospital')
+        ->not->toContain('<span class="cb">X</span> DISCHARGED HOME')
+        ->not->toContain('<span class="cb">X</span> DIED IN ED');
 });
 
 test('discharged outcome ticks DISCHARGED HOME and no other disposition checkbox', function () {


### PR DESCRIPTION
## Summary
- Adds a new **1-page compact** emergency triage service order print template alongside the existing 2-page detailed one, to save paper.
- Adds a `service_order_template` column on `service_departments` so admins can configure which print template each department uses.
- Adds a "Service Order Print Template" select field to the Filament ServiceDepartment admin resource, with a table badge column showing the current selection.
- `ServiceOrderPdfPrintController` now resolves the department's configured template and falls back to the existing detailed template when unset, so no existing department's behavior changes unless explicitly reconfigured.

Closes #34.

## Details
- `app/Enum/ServiceOrderTemplate.php` — string-backed enum (`EmergencyTriageDetailed`, `EmergencyTriageCompact`) with `label()` and `view()`.
- `resources/views/pdfs/serviceorder-triage-compact.blade.php` — new condensed layout: patient info, triage note, single consent block, vitals, exam findings, treatment/investigation, compact drug chart, diagnosis + disposition checkboxes, signatures.
- Verified with dompdf against realistic data (2 prescriptions, vitals, discharge outcome): compact template renders as exactly 1 page, detailed template as 2 pages.

## Test plan
- [x] `php artisan test --compact` — full suite: 650 passed, 1 pre-existing unrelated failure (`AbacusClosingIntegrationTest`, confirmed failing on `main` too)
- [x] New/updated tests (27) covering: model enum cast, controller template branching (default + compact), compact template content fidelity, Filament create/default behavior
- [x] `vendor/bin/pint --dirty` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)