### PR TITLE
feat: add Death, Referral, and Birth certificates with QR verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,13 @@ yarn-error.log
 supervisord.log
 supervisord.log
 .pnpm-store
+# Auto-written by newer local pnpm versions (e.g. v11) when a build script is
+# ignored, even though the project isn't a workspace and Docker/CI's pinned
+# pnpm@9 doesn't need it — approval lives in package.json's
+# pnpm.onlyBuiltDependencies instead. Committing this file breaks the Docker
+# build (`packages field missing or empty`), since it gets copied in before
+# `pnpm run build` runs.
+/pnpm-workspace.yaml
 /storybook-static
 public/vendor/blade-health-icons/
 

--- a/app/Enum/DeathCertificateManner.php
+++ b/app/Enum/DeathCertificateManner.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Enum;
+
+enum DeathCertificateManner: string
+{
+    case Natural = 'natural';
+    case Accident = 'accident';
+    case Suicide = 'suicide';
+    case Homicide = 'homicide';
+    case Undetermined = 'undetermined';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Natural => 'Natural',
+            self::Accident => 'Accident',
+            self::Suicide => 'Suicide',
+            self::Homicide => 'Homicide',
+            self::Undetermined => 'Undetermined',
+        };
+    }
+}

--- a/app/Filament/Admin/Pages/HospitalSettings.php
+++ b/app/Filament/Admin/Pages/HospitalSettings.php
@@ -44,6 +44,7 @@ class HospitalSettings extends Page implements HasForms
             'timezone' => HospitalSetting::get('hospital_timezone', 'Asia/Karachi'),
             'abacus_auto_map_accounts' => (bool) HospitalSetting::get('abacus_auto_map_accounts', false),
             'appointment_priority_mode' => HospitalSetting::get('appointment_priority_mode', AppointmentPriorityMode::Standard->value),
+            'certificate_verification_domain' => HospitalSetting::get('certificate_verification_domain', config('app.url')),
         ]);
     }
 
@@ -98,6 +99,11 @@ class HospitalSettings extends Page implements HasForms
                         ->mapWithKeys(fn (AppointmentPriorityMode $mode) => [$mode->value => $mode->label()])
                         ->toArray())
                     ->default(AppointmentPriorityMode::Standard->value),
+                TextInput::make('certificate_verification_domain')
+                    ->label('Certificate Verification Domain')
+                    ->helperText('Public domain used to build the QR code link printed on Death and Birth certificates (e.g. https://verify.example.com). Defaults to this app\'s URL when left blank.')
+                    ->url()
+                    ->maxLength(255),
             ])
             ->statePath('data');
     }
@@ -116,6 +122,7 @@ class HospitalSettings extends Page implements HasForms
         HospitalSetting::set('hospital_timezone', $state['timezone'] ?? 'Asia/Karachi');
         HospitalSetting::set('abacus_auto_map_accounts', $state['abacus_auto_map_accounts'] ?? false);
         HospitalSetting::set('appointment_priority_mode', $state['appointment_priority_mode'] ?? AppointmentPriorityMode::Standard->value);
+        HospitalSetting::set('certificate_verification_domain', $state['certificate_verification_domain'] ?? null);
 
         DateHelper::flushTimezoneCache();
 

--- a/app/Filament/Admin/Resources/BirthCertificates/BirthCertificateResource.php
+++ b/app/Filament/Admin/Resources/BirthCertificates/BirthCertificateResource.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace App\Filament\Admin\Resources\BirthCertificates;
+
+use App\Filament\Admin\Resources\BirthCertificates\Pages\CreateBirthCertificate;
+use App\Filament\Admin\Resources\BirthCertificates\Pages\EditBirthCertificate;
+use App\Filament\Admin\Resources\BirthCertificates\Pages\ListBirthCertificates;
+use App\Models\BirthCertificate;
+use App\Models\ServiceOrder;
+use BackedEnum;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\TimePicker;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use UnitEnum;
+
+class BirthCertificateResource extends Resource
+{
+    protected static ?string $model = BirthCertificate::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedGift;
+
+    protected static string|UnitEnum|null $navigationGroup = 'Clinical';
+
+    protected static ?int $navigationSort = 1;
+
+    protected static ?string $recordTitleAttribute = 'birth_certificate_number';
+
+    public static function form(Schema $schema): Schema
+    {
+        $isLocked = fn (?BirthCertificate $record) => $record?->is_locked ?? false;
+
+        return $schema->components([
+            Select::make('service_order_id')
+                ->label('Service Order (SO number or SO short code)')
+                ->searchable()
+                ->getSearchResultsUsing(fn (string $search) => ServiceOrder::query()
+                    ->where('so_number', 'like', "%{$search}%")
+                    ->orWhere('so_short', 'like', "%{$search}%")
+                    ->limit(50)
+                    ->get()
+                    ->mapWithKeys(fn (ServiceOrder $serviceOrder) => [
+                        $serviceOrder->id => "{$serviceOrder->so_number} ({$serviceOrder->so_short})",
+                    ]))
+                ->getOptionLabelUsing(function ($value) {
+                    $serviceOrder = ServiceOrder::find($value);
+
+                    return $serviceOrder ? "{$serviceOrder->so_number} ({$serviceOrder->so_short})" : null;
+                })
+                ->required()
+                ->disabledOn('edit'),
+            TextInput::make('birth_certificate_number')
+                ->disabled()
+                ->dehydrated(false)
+                ->visibleOn('edit'),
+            TextInput::make('child_name')->maxLength(255)->disabled($isLocked),
+            DatePicker::make('date_of_birth')->disabled($isLocked),
+            TimePicker::make('time_of_birth')->disabled($isLocked),
+            Select::make('gender')
+                ->options(['m' => 'Male', 'f' => 'Female', 't' => 'Transgender', 'o' => 'Other'])
+                ->native(false)
+                ->disabled($isLocked),
+            TextInput::make('place_of_birth')->maxLength(255)->disabled($isLocked),
+            TextInput::make('weight_at_birth')->numeric()->suffix('kg')->disabled($isLocked),
+            TextInput::make('mother_name')->maxLength(255)->disabled($isLocked),
+            TextInput::make('mother_cnic')->maxLength(20)->disabled($isLocked),
+            TextInput::make('father_name')->maxLength(255)->disabled($isLocked),
+            TextInput::make('father_cnic')->maxLength(20)->disabled($isLocked),
+            Select::make('attending_doctor_id')
+                ->relationship('attendingDoctor', 'name')
+                ->searchable()
+                ->disabled($isLocked),
+            Textarea::make('remarks')->columnSpanFull()->disabled($isLocked),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->defaultSort('id', 'desc')
+            ->columns([
+                TextColumn::make('birth_certificate_number')->searchable()->sortable(),
+                TextColumn::make('serviceOrder.so_number')->label('Service Order')->searchable(),
+                TextColumn::make('child_name')->searchable(),
+                TextColumn::make('date_of_birth')->date()->sortable(),
+                IconColumn::make('is_locked')->label('Locked')->boolean(),
+                TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->recordActions([
+                EditAction::make(),
+                DeleteAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListBirthCertificates::route('/'),
+            'create' => CreateBirthCertificate::route('/create'),
+            'edit' => EditBirthCertificate::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/BirthCertificates/Pages/CreateBirthCertificate.php
+++ b/app/Filament/Admin/Resources/BirthCertificates/Pages/CreateBirthCertificate.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Admin\Resources\BirthCertificates\Pages;
+
+use App\Filament\Admin\Resources\BirthCertificates\BirthCertificateResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateBirthCertificate extends CreateRecord
+{
+    protected static string $resource = BirthCertificateResource::class;
+}

--- a/app/Filament/Admin/Resources/BirthCertificates/Pages/EditBirthCertificate.php
+++ b/app/Filament/Admin/Resources/BirthCertificates/Pages/EditBirthCertificate.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Filament\Admin\Resources\BirthCertificates\Pages;
+
+use App\Filament\Admin\Resources\BirthCertificates\BirthCertificateResource;
+use Filament\Actions\Action;
+use Filament\Actions\DeleteAction;
+use Filament\Notifications\Notification;
+use Filament\Resources\Pages\EditRecord;
+
+class EditBirthCertificate extends EditRecord
+{
+    protected static string $resource = BirthCertificateResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('lock')
+                ->label('Lock Certificate')
+                ->icon('heroicon-o-lock-closed')
+                ->color('danger')
+                ->requiresConfirmation()
+                ->modalHeading('Lock this birth certificate?')
+                ->modalDescription('Once locked, this certificate can no longer be edited, and it will only be included when printing the service order once locked.')
+                ->visible(fn () => ! $this->record->is_locked)
+                ->action(function (): void {
+                    $this->record->update([
+                        'is_locked' => true,
+                        'locked_at' => now(),
+                        'locked_by' => auth()->id(),
+                    ]);
+
+                    Notification::make()
+                        ->title('Birth certificate locked')
+                        ->success()
+                        ->send();
+
+                    $this->fillForm();
+                }),
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/BirthCertificates/Pages/ListBirthCertificates.php
+++ b/app/Filament/Admin/Resources/BirthCertificates/Pages/ListBirthCertificates.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Admin\Resources\BirthCertificates\Pages;
+
+use App\Filament\Admin\Resources\BirthCertificates\BirthCertificateResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListBirthCertificates extends ListRecords
+{
+    protected static string $resource = BirthCertificateResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/DeathCertificates/DeathCertificateResource.php
+++ b/app/Filament/Admin/Resources/DeathCertificates/DeathCertificateResource.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Filament\Admin\Resources\DeathCertificates;
+
+use App\Enum\DeathCertificateManner;
+use App\Filament\Admin\Resources\DeathCertificates\Pages\CreateDeathCertificate;
+use App\Filament\Admin\Resources\DeathCertificates\Pages\EditDeathCertificate;
+use App\Filament\Admin\Resources\DeathCertificates\Pages\ListDeathCertificates;
+use App\Models\DeathCertificate;
+use BackedEnum;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\TimePicker;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use UnitEnum;
+
+class DeathCertificateResource extends Resource
+{
+    protected static ?string $model = DeathCertificate::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedDocumentText;
+
+    protected static string|UnitEnum|null $navigationGroup = 'Clinical';
+
+    protected static ?int $navigationSort = 2;
+
+    protected static ?string $recordTitleAttribute = 'certificate_number';
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            Select::make('service_order_id')
+                ->relationship('serviceOrder', 'so_number')
+                ->searchable()
+                ->required()
+                ->disabledOn('edit'),
+            TextInput::make('certificate_number')
+                ->disabled()
+                ->dehydrated(false)
+                ->visibleOn('edit'),
+            DatePicker::make('date_of_death'),
+            TimePicker::make('time_of_death'),
+            TextInput::make('place_of_death')->maxLength(255),
+            Select::make('manner_of_death')
+                ->options(collect(DeathCertificateManner::cases())
+                    ->mapWithKeys(fn (DeathCertificateManner $manner) => [$manner->value => $manner->label()])
+                    ->toArray())
+                ->native(false),
+            Textarea::make('antecedent_cause')->columnSpanFull(),
+            TextInput::make('informant_name')->maxLength(255),
+            TextInput::make('informant_relation')->maxLength(255),
+            TextInput::make('informant_cnic')->maxLength(20),
+            Textarea::make('remarks')->columnSpanFull(),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->defaultSort('id', 'desc')
+            ->columns([
+                TextColumn::make('certificate_number')->searchable()->sortable(),
+                TextColumn::make('serviceOrder.so_number')->label('Service Order')->searchable(),
+                TextColumn::make('serviceOrder.patient.name')->label('Patient')->searchable(),
+                TextColumn::make('date_of_death')->date()->sortable(),
+                TextColumn::make('manner_of_death')->badge(),
+                TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->recordActions([
+                EditAction::make(),
+                DeleteAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListDeathCertificates::route('/'),
+            'create' => CreateDeathCertificate::route('/create'),
+            'edit' => EditDeathCertificate::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/DeathCertificates/Pages/CreateDeathCertificate.php
+++ b/app/Filament/Admin/Resources/DeathCertificates/Pages/CreateDeathCertificate.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Admin\Resources\DeathCertificates\Pages;
+
+use App\Filament\Admin\Resources\DeathCertificates\DeathCertificateResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateDeathCertificate extends CreateRecord
+{
+    protected static string $resource = DeathCertificateResource::class;
+}

--- a/app/Filament/Admin/Resources/DeathCertificates/Pages/EditDeathCertificate.php
+++ b/app/Filament/Admin/Resources/DeathCertificates/Pages/EditDeathCertificate.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Admin\Resources\DeathCertificates\Pages;
+
+use App\Filament\Admin\Resources\DeathCertificates\DeathCertificateResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditDeathCertificate extends EditRecord
+{
+    protected static string $resource = DeathCertificateResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/DeathCertificates/Pages/ListDeathCertificates.php
+++ b/app/Filament/Admin/Resources/DeathCertificates/Pages/ListDeathCertificates.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Admin\Resources\DeathCertificates\Pages;
+
+use App\Filament\Admin\Resources\DeathCertificates\DeathCertificateResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListDeathCertificates extends ListRecords
+{
+    protected static string $resource = DeathCertificateResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/ReferralCertificates/Pages/CreateReferralCertificate.php
+++ b/app/Filament/Admin/Resources/ReferralCertificates/Pages/CreateReferralCertificate.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Admin\Resources\ReferralCertificates\Pages;
+
+use App\Filament\Admin\Resources\ReferralCertificates\ReferralCertificateResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateReferralCertificate extends CreateRecord
+{
+    protected static string $resource = ReferralCertificateResource::class;
+}

--- a/app/Filament/Admin/Resources/ReferralCertificates/Pages/EditReferralCertificate.php
+++ b/app/Filament/Admin/Resources/ReferralCertificates/Pages/EditReferralCertificate.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Admin\Resources\ReferralCertificates\Pages;
+
+use App\Filament\Admin\Resources\ReferralCertificates\ReferralCertificateResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditReferralCertificate extends EditRecord
+{
+    protected static string $resource = ReferralCertificateResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/ReferralCertificates/Pages/ListReferralCertificates.php
+++ b/app/Filament/Admin/Resources/ReferralCertificates/Pages/ListReferralCertificates.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Admin\Resources\ReferralCertificates\Pages;
+
+use App\Filament\Admin\Resources\ReferralCertificates\ReferralCertificateResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListReferralCertificates extends ListRecords
+{
+    protected static string $resource = ReferralCertificateResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/ReferralCertificates/ReferralCertificateResource.php
+++ b/app/Filament/Admin/Resources/ReferralCertificates/ReferralCertificateResource.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Filament\Admin\Resources\ReferralCertificates;
+
+use App\Filament\Admin\Resources\ReferralCertificates\Pages\CreateReferralCertificate;
+use App\Filament\Admin\Resources\ReferralCertificates\Pages\EditReferralCertificate;
+use App\Filament\Admin\Resources\ReferralCertificates\Pages\ListReferralCertificates;
+use App\Models\ReferralCertificate;
+use BackedEnum;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\RichEditor;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use UnitEnum;
+
+class ReferralCertificateResource extends Resource
+{
+    protected static ?string $model = ReferralCertificate::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedPaperAirplane;
+
+    protected static string|UnitEnum|null $navigationGroup = 'Clinical';
+
+    protected static ?int $navigationSort = 3;
+
+    protected static ?string $recordTitleAttribute = 'referral_number';
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            Select::make('service_order_id')
+                ->relationship('serviceOrder', 'so_number')
+                ->searchable()
+                ->required()
+                ->disabledOn('edit'),
+            TextInput::make('referral_number')
+                ->disabled()
+                ->dehydrated(false)
+                ->visibleOn('edit'),
+            TextInput::make('receiving_facility_name')->maxLength(255),
+            RichEditor::make('notes')->columnSpanFull(),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->defaultSort('id', 'desc')
+            ->columns([
+                TextColumn::make('referral_number')->searchable()->sortable(),
+                TextColumn::make('serviceOrder.so_number')->label('Service Order')->searchable(),
+                TextColumn::make('serviceOrder.patient.name')->label('Patient')->searchable(),
+                TextColumn::make('receiving_facility_name')->label('Receiving Facility')->searchable(),
+                TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->recordActions([
+                EditAction::make(),
+                DeleteAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListReferralCertificates::route('/'),
+            'create' => CreateReferralCertificate::route('/create'),
+            'edit' => EditReferralCertificate::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Helpers/QrCodeHelper.php
+++ b/app/Helpers/QrCodeHelper.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Helpers;
+
+use App\Models\HospitalSetting;
+use Endroid\QrCode\Builder\Builder;
+use Endroid\QrCode\Writer\PngWriter;
+
+class QrCodeHelper
+{
+    /**
+     * Base64 PNG data URI for a QR code encoding the given URL, ready to
+     * drop straight into an <img src="..."> — dompdf can't fetch external
+     * images reliably at print time, so this avoids a network round trip.
+     */
+    public static function dataUri(string $url, int $size = 180): string
+    {
+        return (new Builder)
+            ->build(
+                writer: new PngWriter,
+                data: $url,
+                size: $size,
+                margin: 2,
+            )
+            ->getDataUri();
+    }
+
+    /**
+     * Build a short public verification URL from the configured domain
+     * (falls back to this app's own URL when the hospital hasn't set one).
+     */
+    public static function verificationUrl(string $path): string
+    {
+        $domain = HospitalSetting::get('certificate_verification_domain', config('app.url'));
+        $domain = is_string($domain) && $domain !== '' ? $domain : config('app.url');
+
+        return rtrim((string) $domain, '/').'/'.ltrim($path, '/');
+    }
+}

--- a/app/Http/Controllers/Api/DepartmentController.php
+++ b/app/Http/Controllers/Api/DepartmentController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api;
 use App\Enum\TreatmentOutcome;
 use App\Http\Controllers\Controller;
 use App\Models\Icd10Code;
+use App\Models\ReferralCertificate;
 use App\Models\ServiceDepartment;
 use App\Models\ServiceOrder;
 use App\Models\Transaction;
@@ -64,6 +65,7 @@ class DepartmentController extends Controller
                 Rule::requiredIf(fn () => $isEmergency && $finalize && $request->input('outcome') === TreatmentOutcome::Referred->value),
                 'nullable', 'string', 'max:255',
             ],
+            'referral_notes' => ['nullable', 'string', 'max:10000'],
             'department_specific_data' => ['nullable', 'array'],
             'dental_chart' => ['nullable', 'array'],
             'triage_id' => [Rule::requiredIf($isEmergency), 'nullable', 'integer', 'exists:triages,id'],
@@ -84,6 +86,12 @@ class DepartmentController extends Controller
 
         $vitals = $data['vitals'] ?? null;
         unset($data['vitals']);
+
+        // referral_notes (CKEditor-authored referral letter body) lives on
+        // ReferralCertificate, not TreatmentRecord — pulled out of $data so
+        // it doesn't hit an unknown-column error on create()/update().
+        $referralNotes = $data['referral_notes'] ?? null;
+        unset($data['referral_notes']);
 
         if (! empty($data['icd10_code_id'])) {
             $icd = Icd10Code::find($data['icd10_code_id']);
@@ -113,6 +121,15 @@ class DepartmentController extends Controller
                 'is_finalized' => $finalize,
                 'finalized_at' => $finalize ? Carbon::now() : null,
                 ...$data,
+            ]);
+        }
+
+        if ($treatmentRecord->outcome === TreatmentOutcome::Referred && $referralNotes !== null) {
+            // The observer already ensured a ReferralCertificate exists for
+            // this outcome transition (fired synchronously during the save
+            // above) — fill in the doctor-authored letter body.
+            $serviceOrder->referralCertificate?->update([
+                'notes' => ReferralCertificate::sanitizeNotes($referralNotes),
             ]);
         }
 

--- a/app/Http/Controllers/Api/IndController.php
+++ b/app/Http/Controllers/Api/IndController.php
@@ -2,11 +2,13 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\Enum\TreatmentOutcome;
 use App\Http\Controllers\Controller;
 use App\Models\Bed;
 use App\Models\BedAssignment;
 use App\Models\Icd10Code;
 use App\Models\Patient;
+use App\Models\ReferralCertificate;
 use App\Models\ServiceOrder;
 use App\Models\TreatmentRecord;
 use App\Models\VitalSign;
@@ -187,6 +189,7 @@ class IndController extends Controller
             'follow_up_date' => ['nullable', 'date'],
             'outcome' => ['nullable', 'string', 'max:50'],
             'referral_to' => ['nullable', 'string', 'max:255'],
+            'referral_notes' => ['nullable', 'string', 'max:10000'],
             'department_specific_data' => ['nullable', 'array'],
             'finalize' => ['nullable', 'boolean'],
             'vitals' => ['nullable', 'array'],
@@ -204,6 +207,8 @@ class IndController extends Controller
         unset($data['finalize']);
         $vitals = $data['vitals'] ?? null;
         unset($data['vitals']);
+        $referralNotes = $data['referral_notes'] ?? null;
+        unset($data['referral_notes']);
 
         // Auto-sync diagnosis_code from the ICD-10 FK when provided.
         if (! empty($data['icd10_code_id'])) {
@@ -234,6 +239,12 @@ class IndController extends Controller
                 'is_finalized' => $finalize,
                 'finalized_at' => $finalize ? Carbon::now() : null,
                 ...$data,
+            ]);
+        }
+
+        if ($treatmentRecord->outcome === TreatmentOutcome::Referred && $referralNotes !== null) {
+            $serviceOrder->referralCertificate?->update([
+                'notes' => ReferralCertificate::sanitizeNotes($referralNotes),
             ]);
         }
 

--- a/app/Http/Controllers/Api/OpdController.php
+++ b/app/Http/Controllers/Api/OpdController.php
@@ -2,10 +2,12 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\Enum\TreatmentOutcome;
 use App\Helpers\DateHelper;
 use App\Http\Controllers\Controller;
 use App\Models\Icd10Code;
 use App\Models\Patient;
+use App\Models\ReferralCertificate;
 use App\Models\ServiceOrder;
 use App\Models\TreatmentRecord;
 use App\Models\VitalSign;
@@ -111,6 +113,7 @@ class OpdController extends Controller
             'follow_up_date' => ['nullable', 'date'],
             'outcome' => ['nullable', 'string', 'max:50'],
             'referral_to' => ['nullable', 'string', 'max:255'],
+            'referral_notes' => ['nullable', 'string', 'max:10000'],
             'department_specific_data' => ['nullable', 'array'],
             'finalize' => ['nullable', 'boolean'],
             // Vital signs
@@ -130,6 +133,9 @@ class OpdController extends Controller
 
         $vitals = $data['vitals'] ?? null;
         unset($data['vitals']);
+
+        $referralNotes = $data['referral_notes'] ?? null;
+        unset($data['referral_notes']);
 
         // Auto-sync diagnosis_code from the ICD-10 FK when provided.
         if (! empty($data['icd10_code_id'])) {
@@ -160,6 +166,12 @@ class OpdController extends Controller
                 'is_finalized' => $finalize,
                 'finalized_at' => $finalize ? Carbon::now() : null,
                 ...$data,
+            ]);
+        }
+
+        if ($treatmentRecord->outcome === TreatmentOutcome::Referred && $referralNotes !== null) {
+            $serviceOrder->referralCertificate?->update([
+                'notes' => ReferralCertificate::sanitizeNotes($referralNotes),
             ]);
         }
 

--- a/app/Http/Controllers/Prints/ServiceOrderPdfPrintController.php
+++ b/app/Http/Controllers/Prints/ServiceOrderPdfPrintController.php
@@ -25,6 +25,9 @@ class ServiceOrderPdfPrintController extends Controller
             'treatmentRecord.attachments',
             'treatmentRecord.treatingDoctor',
             'treatmentRecord.vitalSigns',
+            'deathCertificate',
+            'referralCertificate',
+            'birthCertificate.attendingDoctor',
         ])->findOrFail($id);
 
         $patient = $serviceOrder->patient;
@@ -47,6 +50,43 @@ class ServiceOrderPdfPrintController extends Controller
             'patient' => $patient,
             'pastDiagnoses' => $pastDiagnoses,
         ])->render();
+
+        $extraPages = '';
+
+        if ($certificate = $serviceOrder->deathCertificate) {
+            $extraPages .= view('pdfs.death-certificate', [
+                'serviceOrder' => $serviceOrder,
+                'patient' => $patient,
+                'certificate' => $certificate,
+            ])->render();
+        }
+
+        if ($referral = $serviceOrder->referralCertificate) {
+            $extraPages .= view('pdfs.referral-certificate', [
+                'serviceOrder' => $serviceOrder,
+                'patient' => $patient,
+                'referral' => $referral,
+            ])->render();
+        }
+
+        // Birth certificates are admin-authored and only print once reviewed
+        // and locked — an unlocked draft never appears on the SO printout.
+        if (($birth = $serviceOrder->birthCertificate) && $birth->is_locked) {
+            $extraPages .= view('pdfs.birth-certificate', [
+                'serviceOrder' => $serviceOrder,
+                'patient' => $patient,
+                'certificate' => $birth,
+            ])->render();
+        }
+
+        if ($extraPages !== '') {
+            // The base templates are full HTML documents; splice the extra
+            // pages in before the closing </body> so dompdf parses one
+            // document instead of concatenated, technically-invalid markup.
+            $html = str_contains($html, '</body>')
+                ? str_replace('</body>', $extraPages.'</body>', $html)
+                : $html.$extraPages;
+        }
 
         $fileName = 'ED-Clinical-Performa-'.($serviceOrder->id ?? Str::uuid()).'.pdf';
 

--- a/app/Http/Controllers/PublicCertificateController.php
+++ b/app/Http/Controllers/PublicCertificateController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\BirthCertificate;
+use App\Models\DeathCertificate;
+use Illuminate\View\View;
+
+/**
+ * Unauthenticated, token-gated verification pages for Death and Birth
+ * certificates — reached by scanning the QR code printed on each document.
+ * Access control is the unguessable `verification_token`, not a login wall.
+ */
+class PublicCertificateController extends Controller
+{
+    public function deathCertificate(string $token): View
+    {
+        $certificate = DeathCertificate::with(['serviceOrder.patient'])
+            ->where('verification_token', $token)
+            ->firstOrFail();
+
+        return view('public.death-certificate', [
+            'certificate' => $certificate,
+            'patient' => $certificate->serviceOrder->patient,
+        ]);
+    }
+
+    public function birthCertificate(string $token): View
+    {
+        $certificate = BirthCertificate::with(['serviceOrder.patient', 'attendingDoctor'])
+            ->where('verification_token', $token)
+            ->where('is_locked', true)
+            ->firstOrFail();
+
+        return view('public.birth-certificate', [
+            'certificate' => $certificate,
+            'patient' => $certificate->serviceOrder->patient,
+        ]);
+    }
+}

--- a/app/Models/BirthCertificate.php
+++ b/app/Models/BirthCertificate.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Models;
+
+use App\Models\Concerns\HasVerificationToken;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+class BirthCertificate extends Model
+{
+    use HasFactory, HasVerificationToken, SoftDeletes;
+
+    protected $fillable = [
+        'service_order_id',
+        'birth_certificate_number',
+        'verification_token',
+        'child_name',
+        'date_of_birth',
+        'time_of_birth',
+        'gender',
+        'place_of_birth',
+        'weight_at_birth',
+        'mother_name',
+        'mother_cnic',
+        'father_name',
+        'father_cnic',
+        'attending_doctor_id',
+        'remarks',
+        'is_locked',
+        'locked_at',
+        'locked_by',
+        'created_by',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'date_of_birth' => 'date',
+            'weight_at_birth' => 'decimal:2',
+            'is_locked' => 'boolean',
+            'locked_at' => 'datetime',
+        ];
+    }
+
+    protected static function booted(): void
+    {
+        static::creating(function (BirthCertificate $certificate): void {
+            if (empty($certificate->birth_certificate_number)) {
+                $certificate->birth_certificate_number = static::generateCertificateNumber();
+            }
+        });
+
+        static::updating(function (BirthCertificate $certificate): void {
+            $dirtyAttributes = array_diff(array_keys($certificate->getDirty()), ['updated_at']);
+
+            if ($certificate->getOriginal('is_locked') && count($dirtyAttributes) > 0) {
+                throw ValidationException::withMessages([
+                    'birth_certificate' => 'Locked birth certificates cannot be modified.',
+                ]);
+            }
+        });
+
+        static::deleting(function (BirthCertificate $certificate): void {
+            if ($certificate->isForceDeleting()) {
+                throw new \RuntimeException('Hard delete is not allowed for birth certificates.');
+            }
+        });
+    }
+
+    public function serviceOrder(): BelongsTo
+    {
+        return $this->belongsTo(ServiceOrder::class);
+    }
+
+    public function attendingDoctor(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'attending_doctor_id');
+    }
+
+    public function lockedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'locked_by');
+    }
+
+    public function createdBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    public static function generateCertificateNumber(): string
+    {
+        return DB::transaction(function () {
+            $now = Carbon::now();
+            $year = $now->format('Y');
+            $month = $now->format('m');
+            $prefix = "BC/{$year}/{$month}/";
+
+            $existingNumbers = self::withTrashed()
+                ->where('birth_certificate_number', 'like', "{$prefix}%")
+                ->lockForUpdate()
+                ->pluck('birth_certificate_number');
+
+            $maxSequence = 0;
+            foreach ($existingNumbers as $certificateNumber) {
+                $parts = explode('/', (string) $certificateNumber);
+                $sequence = (int) ($parts[3] ?? 0);
+                if ($sequence > $maxSequence) {
+                    $maxSequence = $sequence;
+                }
+            }
+
+            $nextSequence = $maxSequence + 1;
+            $count = str_pad((string) $nextSequence, 4, '0', STR_PAD_LEFT);
+
+            return "{$prefix}{$count}";
+        });
+    }
+}

--- a/app/Models/Concerns/HasVerificationToken.php
+++ b/app/Models/Concerns/HasVerificationToken.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models\Concerns;
+
+use Illuminate\Support\Str;
+
+trait HasVerificationToken
+{
+    protected static function bootHasVerificationToken(): void
+    {
+        static::creating(function ($model): void {
+            if (empty($model->verification_token)) {
+                $model->verification_token = static::generateVerificationToken();
+            }
+        });
+    }
+
+    public static function generateVerificationToken(): string
+    {
+        do {
+            $token = Str::random(40);
+        } while (static::withTrashed()->where('verification_token', $token)->exists());
+
+        return $token;
+    }
+}

--- a/app/Models/DeathCertificate.php
+++ b/app/Models/DeathCertificate.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Models;
+
+use App\Enum\DeathCertificateManner;
+use App\Models\Concerns\HasVerificationToken;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+
+class DeathCertificate extends Model
+{
+    use HasFactory, HasVerificationToken, SoftDeletes;
+
+    protected $fillable = [
+        'service_order_id',
+        'certificate_number',
+        'verification_token',
+        'date_of_death',
+        'time_of_death',
+        'place_of_death',
+        'manner_of_death',
+        'antecedent_cause',
+        'informant_name',
+        'informant_relation',
+        'informant_cnic',
+        'remarks',
+        'created_by',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'date_of_death' => 'date',
+            'manner_of_death' => DeathCertificateManner::class,
+        ];
+    }
+
+    protected static function booted(): void
+    {
+        static::creating(function (DeathCertificate $certificate): void {
+            if (empty($certificate->certificate_number)) {
+                $certificate->certificate_number = static::generateCertificateNumber();
+            }
+        });
+
+        static::deleting(function (DeathCertificate $certificate): void {
+            if ($certificate->isForceDeleting()) {
+                throw new \RuntimeException('Hard delete is not allowed for death certificates.');
+            }
+        });
+    }
+
+    public function serviceOrder(): BelongsTo
+    {
+        return $this->belongsTo(ServiceOrder::class);
+    }
+
+    public function createdBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    public static function generateCertificateNumber(): string
+    {
+        return DB::transaction(function () {
+            $now = Carbon::now();
+            $year = $now->format('Y');
+            $month = $now->format('m');
+            $prefix = "DC/{$year}/{$month}/";
+
+            $existingNumbers = self::withTrashed()
+                ->where('certificate_number', 'like', "{$prefix}%")
+                ->lockForUpdate()
+                ->pluck('certificate_number');
+
+            $maxSequence = 0;
+            foreach ($existingNumbers as $certificateNumber) {
+                $parts = explode('/', (string) $certificateNumber);
+                $sequence = (int) ($parts[3] ?? 0);
+                if ($sequence > $maxSequence) {
+                    $maxSequence = $sequence;
+                }
+            }
+
+            $nextSequence = $maxSequence + 1;
+            $count = str_pad((string) $nextSequence, 4, '0', STR_PAD_LEFT);
+
+            return "{$prefix}{$count}";
+        });
+    }
+}

--- a/app/Models/ReferralCertificate.php
+++ b/app/Models/ReferralCertificate.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+
+class ReferralCertificate extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $fillable = [
+        'service_order_id',
+        'referral_number',
+        'receiving_facility_name',
+        'notes',
+        'created_by',
+    ];
+
+    protected static function booted(): void
+    {
+        static::creating(function (ReferralCertificate $certificate): void {
+            if (empty($certificate->referral_number)) {
+                $certificate->referral_number = static::generateReferralNumber();
+            }
+        });
+
+        static::deleting(function (ReferralCertificate $certificate): void {
+            if ($certificate->isForceDeleting()) {
+                throw new \RuntimeException('Hard delete is not allowed for referral certificates.');
+            }
+        });
+    }
+
+    public function serviceOrder(): BelongsTo
+    {
+        return $this->belongsTo(ServiceOrder::class);
+    }
+
+    public function createdBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    /**
+     * Best-effort HTML sanitization for doctor-authored referral notes.
+     * There is no HTML purifier package in this project (adding one is a
+     * dependency decision beyond this feature's scope), so this only
+     * allowlists CKEditor's basic formatting tags and strips event-handler
+     * attributes / javascript: URIs on whatever tags remain.
+     */
+    public static function sanitizeNotes(?string $html): ?string
+    {
+        if ($html === null || trim($html) === '') {
+            return null;
+        }
+
+        $allowedTags = '<p><br><strong><b><em><i><u><ul><ol><li><span><h1><h2><h3><h4><blockquote><a>';
+        $sanitized = strip_tags($html, $allowedTags);
+        $sanitized = preg_replace('/\son\w+\s*=\s*("[^"]*"|\'[^\']*\'|[^\s>]+)/i', '', $sanitized);
+        $sanitized = preg_replace('/(href|src)\s*=\s*(["\'])\s*javascript:.*?\2/i', '$1=""', $sanitized);
+
+        return $sanitized;
+    }
+
+    public static function generateReferralNumber(): string
+    {
+        return DB::transaction(function () {
+            $now = Carbon::now();
+            $year = $now->format('Y');
+            $month = $now->format('m');
+            $prefix = "RF/{$year}/{$month}/";
+
+            $existingNumbers = self::withTrashed()
+                ->where('referral_number', 'like', "{$prefix}%")
+                ->lockForUpdate()
+                ->pluck('referral_number');
+
+            $maxSequence = 0;
+            foreach ($existingNumbers as $referralNumber) {
+                $parts = explode('/', (string) $referralNumber);
+                $sequence = (int) ($parts[3] ?? 0);
+                if ($sequence > $maxSequence) {
+                    $maxSequence = $sequence;
+                }
+            }
+
+            $nextSequence = $maxSequence + 1;
+            $count = str_pad((string) $nextSequence, 4, '0', STR_PAD_LEFT);
+
+            return "{$prefix}{$count}";
+        });
+    }
+}

--- a/app/Models/ServiceOrder.php
+++ b/app/Models/ServiceOrder.php
@@ -370,6 +370,21 @@ class ServiceOrder extends Model
         return $this->hasOne(TreatmentRecord::class);
     }
 
+    public function deathCertificate(): HasOne
+    {
+        return $this->hasOne(DeathCertificate::class);
+    }
+
+    public function referralCertificate(): HasOne
+    {
+        return $this->hasOne(ReferralCertificate::class);
+    }
+
+    public function birthCertificate(): HasOne
+    {
+        return $this->hasOne(BirthCertificate::class);
+    }
+
     public function versions(): HasMany
     {
         return $this->hasMany(ServiceOrderVersion::class)->latest('changed_at');

--- a/app/Observers/TreatmentRecordObserver.php
+++ b/app/Observers/TreatmentRecordObserver.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Observers;
+
+use App\Enum\TreatmentOutcome;
+use App\Models\DeathCertificate;
+use App\Models\ReferralCertificate;
+use App\Models\TreatmentRecord;
+
+class TreatmentRecordObserver
+{
+    /**
+     * Handle the TreatmentRecord "saved" event (fires on both create and update).
+     */
+    public function saved(TreatmentRecord $treatmentRecord): void
+    {
+        if ($treatmentRecord->outcome === TreatmentOutcome::Expired) {
+            $this->ensureDeathCertificate($treatmentRecord);
+        }
+
+        if ($treatmentRecord->outcome === TreatmentOutcome::Referred) {
+            $this->ensureReferralCertificate($treatmentRecord);
+        }
+    }
+
+    private function ensureDeathCertificate(TreatmentRecord $treatmentRecord): void
+    {
+        if (DeathCertificate::where('service_order_id', $treatmentRecord->service_order_id)->exists()) {
+            return;
+        }
+
+        $patient = $treatmentRecord->serviceOrder?->patient;
+
+        DeathCertificate::create([
+            'service_order_id' => $treatmentRecord->service_order_id,
+            'date_of_death' => $treatmentRecord->outcome_at?->toDateString(),
+            'time_of_death' => $treatmentRecord->outcome_at?->toTimeString(),
+            'place_of_death' => $treatmentRecord->department?->name,
+            'informant_name' => $patient?->guardian,
+            'informant_relation' => $patient?->relation,
+            'created_by' => $treatmentRecord->recorded_by,
+        ]);
+    }
+
+    private function ensureReferralCertificate(TreatmentRecord $treatmentRecord): void
+    {
+        if (ReferralCertificate::where('service_order_id', $treatmentRecord->service_order_id)->exists()) {
+            return;
+        }
+
+        ReferralCertificate::create([
+            'service_order_id' => $treatmentRecord->service_order_id,
+            'receiving_facility_name' => $treatmentRecord->referral_to,
+            'created_by' => $treatmentRecord->recorded_by,
+        ]);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -14,6 +14,7 @@ use App\Models\ServiceOrder;
 use App\Models\Task;
 use App\Models\Transaction;
 use App\Models\TransactionElement;
+use App\Models\TreatmentRecord;
 use App\Models\User;
 use App\Observers\AppointmentObserver;
 use App\Observers\AssetObserver;
@@ -24,6 +25,7 @@ use App\Observers\PurchaseOrderObserver;
 use App\Observers\TaskObserver;
 use App\Observers\TransactionElementObserver;
 use App\Observers\TransactionObserver;
+use App\Observers\TreatmentRecordObserver;
 use App\Policies\ClosingPolicy;
 use App\Policies\ExpenseVoucherPolicy;
 use App\Policies\PatientPolicy;
@@ -70,6 +72,7 @@ class AppServiceProvider extends ServiceProvider
         Asset::observe(AssetObserver::class);
         Task::observe(TaskObserver::class);
         Appointment::observe(AppointmentObserver::class);
+        TreatmentRecord::observe(TreatmentRecordObserver::class);
 
         Gate::define('viewPulse', function (User $user) {
             return $user->adminProfiles()->count() > 0;

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         "barryvdh/laravel-dompdf": "^3.1",
         "bezhansalleh/filament-panel-switch": "^3.0",
         "blade-ui-kit/blade-heroicons": "^2.7",
+        "endroid/qr-code": "^6.1",
         "filament/filament": "^4.0",
         "inertiajs/inertia-laravel": "^2.0",
         "laravel/fortify": "^1.30",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "67f45cc45a2a6361395eb292d1b27d53",
+    "content-hash": "d184ccc4e3cf067e07fa47e5bae844e0",
     "packages": [
         {
             "name": "andreia/filament-ui-switcher",
@@ -1685,6 +1685,78 @@
                 }
             ],
             "time": "2025-03-06T22:45:56+00:00"
+        },
+        {
+            "name": "endroid/qr-code",
+            "version": "6.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/endroid/qr-code.git",
+                "reference": "5fa534856ed95649d67c0eab0cabc03ab1d8e0e2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/endroid/qr-code/zipball/5fa534856ed95649d67c0eab0cabc03ab1d8e0e2",
+                "reference": "5fa534856ed95649d67c0eab0cabc03ab1d8e0e2",
+                "shasum": ""
+            },
+            "require": {
+                "bacon/bacon-qr-code": "^3.0",
+                "php": "^8.4"
+            },
+            "require-dev": {
+                "endroid/quality": "dev-main",
+                "ext-gd": "*",
+                "khanamiryan/qrcode-detector-decoder": "^2.0.3",
+                "setasign/fpdf": "^1.8.2"
+            },
+            "suggest": {
+                "ext-gd": "Enables you to write PNG images",
+                "khanamiryan/qrcode-detector-decoder": "Enables you to use the image validator",
+                "roave/security-advisories": "Makes sure package versions with known security issues are not installed",
+                "setasign/fpdf": "Enables you to use the PDF writer"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Endroid\\QrCode\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jeroen van den Enden",
+                    "email": "info@endroid.nl"
+                }
+            ],
+            "description": "Endroid QR Code",
+            "homepage": "https://github.com/endroid/qr-code",
+            "keywords": [
+                "code",
+                "endroid",
+                "php",
+                "qr",
+                "qrcode"
+            ],
+            "support": {
+                "issues": "https://github.com/endroid/qr-code/issues",
+                "source": "https://github.com/endroid/qr-code/tree/6.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/endroid",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-05T07:01:58+00:00"
         },
         {
             "name": "ezyang/htmlpurifier",

--- a/database/factories/BirthCertificateFactory.php
+++ b/database/factories/BirthCertificateFactory.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\BirthCertificate;
+use App\Models\ServiceOrder;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class BirthCertificateFactory extends Factory
+{
+    protected $model = BirthCertificate::class;
+
+    public function definition(): array
+    {
+        static $sequence = 0;
+        $sequence++;
+
+        $now = now();
+
+        return [
+            'service_order_id' => ServiceOrder::factory(),
+            'birth_certificate_number' => sprintf('BC/%s/%s/%04d', $now->format('Y'), $now->format('m'), $sequence),
+            'child_name' => fake()->firstName(),
+            'date_of_birth' => $now->toDateString(),
+            'time_of_birth' => $now->toTimeString(),
+            'gender' => fake()->randomElement(['m', 'f']),
+            'place_of_birth' => null,
+            'weight_at_birth' => fake()->randomFloat(2, 2, 4),
+            'mother_name' => fake()->name('female'),
+            'mother_cnic' => null,
+            'father_name' => null,
+            'father_cnic' => null,
+            'attending_doctor_id' => User::factory(),
+            'remarks' => null,
+            'is_locked' => false,
+            'locked_at' => null,
+            'locked_by' => null,
+            'created_by' => User::factory(),
+        ];
+    }
+
+    public function locked(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'is_locked' => true,
+            'locked_at' => now(),
+            'locked_by' => User::factory(),
+        ]);
+    }
+}

--- a/database/factories/DeathCertificateFactory.php
+++ b/database/factories/DeathCertificateFactory.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enum\DeathCertificateManner;
+use App\Models\DeathCertificate;
+use App\Models\ServiceOrder;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class DeathCertificateFactory extends Factory
+{
+    protected $model = DeathCertificate::class;
+
+    public function definition(): array
+    {
+        static $sequence = 0;
+        $sequence++;
+
+        $now = now();
+
+        return [
+            'service_order_id' => ServiceOrder::factory(),
+            'certificate_number' => sprintf('DC/%s/%s/%04d', $now->format('Y'), $now->format('m'), $sequence),
+            'date_of_death' => $now->toDateString(),
+            'time_of_death' => $now->toTimeString(),
+            'place_of_death' => null,
+            'manner_of_death' => null,
+            'antecedent_cause' => null,
+            'informant_name' => null,
+            'informant_relation' => null,
+            'informant_cnic' => null,
+            'remarks' => null,
+            'created_by' => User::factory(),
+        ];
+    }
+
+    public function withManner(DeathCertificateManner $manner): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'manner_of_death' => $manner,
+        ]);
+    }
+}

--- a/database/factories/ReferralCertificateFactory.php
+++ b/database/factories/ReferralCertificateFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ReferralCertificate;
+use App\Models\ServiceOrder;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ReferralCertificateFactory extends Factory
+{
+    protected $model = ReferralCertificate::class;
+
+    public function definition(): array
+    {
+        static $sequence = 0;
+        $sequence++;
+
+        $now = now();
+
+        return [
+            'service_order_id' => ServiceOrder::factory(),
+            'referral_number' => sprintf('RF/%s/%s/%04d', $now->format('Y'), $now->format('m'), $sequence),
+            'receiving_facility_name' => null,
+            'notes' => null,
+            'created_by' => User::factory(),
+        ];
+    }
+}

--- a/database/migrations/2026_08_10_172230_create_death_certificates_table.php
+++ b/database/migrations/2026_08_10_172230_create_death_certificates_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('death_certificates', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('service_order_id')->unique()->constrained('service_orders');
+            $table->string('certificate_number')->unique();
+            $table->date('date_of_death')->nullable();
+            $table->time('time_of_death')->nullable();
+            $table->string('place_of_death')->nullable();
+            $table->string('manner_of_death')->nullable();
+            $table->text('antecedent_cause')->nullable();
+            $table->string('informant_name')->nullable();
+            $table->string('informant_relation')->nullable();
+            $table->string('informant_cnic')->nullable();
+            $table->text('remarks')->nullable();
+            $table->foreignId('created_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('death_certificates');
+    }
+};

--- a/database/migrations/2026_08_10_172231_create_referral_certificates_table.php
+++ b/database/migrations/2026_08_10_172231_create_referral_certificates_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('referral_certificates', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('service_order_id')->unique()->constrained('service_orders');
+            $table->string('referral_number')->unique();
+            $table->string('receiving_facility_name')->nullable();
+            $table->longText('notes')->nullable();
+            $table->foreignId('created_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('referral_certificates');
+    }
+};

--- a/database/migrations/2026_08_10_174559_create_birth_certificates_table.php
+++ b/database/migrations/2026_08_10_174559_create_birth_certificates_table.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('birth_certificates', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('service_order_id')->unique()->constrained('service_orders');
+            $table->string('birth_certificate_number')->unique();
+            $table->string('child_name')->nullable();
+            $table->date('date_of_birth')->nullable();
+            $table->time('time_of_birth')->nullable();
+            $table->string('gender')->nullable();
+            $table->string('place_of_birth')->nullable();
+            $table->decimal('weight_at_birth', 5, 2)->nullable();
+            $table->string('mother_name')->nullable();
+            $table->string('mother_cnic')->nullable();
+            $table->string('father_name')->nullable();
+            $table->string('father_cnic')->nullable();
+            $table->foreignId('attending_doctor_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->text('remarks')->nullable();
+            $table->boolean('is_locked')->default(false);
+            $table->dateTime('locked_at')->nullable();
+            $table->foreignId('locked_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->foreignId('created_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('birth_certificates');
+    }
+};

--- a/database/migrations/2026_08_10_175803_add_verification_token_to_death_and_birth_certificates.php
+++ b/database/migrations/2026_08_10_175803_add_verification_token_to_death_and_birth_certificates.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('death_certificates', function (Blueprint $table) {
+            $table->string('verification_token', 40)->nullable()->unique()->after('certificate_number');
+        });
+
+        Schema::table('birth_certificates', function (Blueprint $table) {
+            $table->string('verification_token', 40)->nullable()->unique()->after('birth_certificate_number');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('death_certificates', function (Blueprint $table) {
+            $table->dropColumn('verification_token');
+        });
+
+        Schema::table('birth_certificates', function (Blueprint $table) {
+            $table->dropColumn('verification_token');
+        });
+    }
+};

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "typescript-eslint": "^8.53.0"
     },
     "dependencies": {
+        "@ckeditor/ckeditor5-react": "^11.2.0",
         "@headlessui/react": "^2.2.9",
         "@inertiajs/react": "^2.3.10",
         "@radix-ui/react-avatar": "^1.1.11",
@@ -53,6 +54,7 @@
         "@types/react": "^19.2.8",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.2",
+        "ckeditor5": "^48.4.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "concurrently": "^9.2.1",

--- a/package.json
+++ b/package.json
@@ -81,5 +81,10 @@
         "@tailwindcss/oxide-win32-x64-msvc": "^4.1.18",
         "lightningcss-linux-x64-gnu": "^1.30.2",
         "lightningcss-win32-x64-msvc": "^1.30.2"
+    },
+    "pnpm": {
+        "onlyBuiltDependencies": [
+            "esbuild"
+        ]
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@ckeditor/ckeditor5-react':
+        specifier: ^11.2.0
+        version: 11.2.0(ckeditor5@48.4.0)(react@19.2.4)
       '@headlessui/react':
         specifier: ^2.2.9
         version: 2.2.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -74,6 +77,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^5.1.2
         version: 5.2.0(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0))
+      ckeditor5:
+        specifier: ^48.4.0
+        version: 48.4.0
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -292,6 +298,197 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@ckeditor/ckeditor5-adapter-ckfinder@48.4.0':
+    resolution: {integrity: sha512-TXEqI816yTntDTfvzKXZ8/ZQPmH15LCKJZfEpRgO3dKwqWdsMBrRhSuOQ3SvPAGk0H10Gzu/ywztXnAcZFsggw==}
+
+  '@ckeditor/ckeditor5-alignment@48.4.0':
+    resolution: {integrity: sha512-04beL17Df8f08q0YfVhtBWD4tKDdkuCWGanolYjCSbC62CJWME3/+gqrtbOrH16RjoS5UdVVwj7XbaOubMaHZQ==}
+
+  '@ckeditor/ckeditor5-autoformat@48.4.0':
+    resolution: {integrity: sha512-ArhvQT9x7GeJcjVI04aj8Ph/A+5eKFkEU05vddVuCva5e46l3X3bE8kXkYgCtFIckTTnDM1W5xgvlAFfS5TE7g==}
+
+  '@ckeditor/ckeditor5-autosave@48.4.0':
+    resolution: {integrity: sha512-OMWQCLp0MAIMMqu7Jm9Xni6nksrrpXT401sOhGWJYvwjobxMS7pVceLBisxGtKQvPL8uokkcBFHwHA1WKKJykw==}
+
+  '@ckeditor/ckeditor5-basic-styles@48.4.0':
+    resolution: {integrity: sha512-S4Hs54X2HNd2sGRPKBoPp8h5xI5WoVnnOVs8+cR8r+r3rMgKZAQQ7ChH6OWbGuw76ayRP4/Rvi31yQ+lTafICQ==}
+
+  '@ckeditor/ckeditor5-block-quote@48.4.0':
+    resolution: {integrity: sha512-T5NrHf0eks/BeQjFll/z6UwNPU4dzpYLmKwJtMLX/GLRfiKLT8R9TkZ2cRi5Cdy1zWtMJJp7KC+WcoJ/TytnCg==}
+
+  '@ckeditor/ckeditor5-bookmark@48.4.0':
+    resolution: {integrity: sha512-nX+/ZCttLR9rIlykoY9PWJUYf3kaz5wZ6FG9kOztP+w03gGJkPmuH7PWWIe3yNpneWF5O+pUYOz9ECDkOdi5dA==}
+
+  '@ckeditor/ckeditor5-ckbox@48.4.0':
+    resolution: {integrity: sha512-CPyLqbLeQtCSzrQiZk8yJwUgyUxTBbgHfAutRuG2j+TP6YNdfosJNham+N9dbAL8YjOzzaflIlJL85OzMA7lVg==}
+
+  '@ckeditor/ckeditor5-ckfinder@48.4.0':
+    resolution: {integrity: sha512-7zsBjnd7Py49SaTtmCjFPuskuwB8uxRzMPVQnsDqVuuOAQaLAFj6l0aoLHJVdCA4trMDhZWX6m59m3aUFf34nw==}
+
+  '@ckeditor/ckeditor5-clipboard@48.4.0':
+    resolution: {integrity: sha512-HK5X3GLesYHon3MTgoZQ9Iy61w7sv0joQqXDCMPy1ycHzcbfiEXrk7a6/cvkEIGiwM4jaxWxmcDWK8HvRtvtOw==}
+
+  '@ckeditor/ckeditor5-cloud-services@48.4.0':
+    resolution: {integrity: sha512-eOY2bn5JFKpbzfK67ACL/vzK28/Xin4utT76WHVzjhr11Xg81FRuTE/qMUyQPMWIFrz0glGOQkQGGeu6YpYpDw==}
+
+  '@ckeditor/ckeditor5-code-block@48.4.0':
+    resolution: {integrity: sha512-W3yzTq+1o7OGlyIBxbZirkJt/znYAzKtOOjqaA5DZkACR3DdRsffDrVIJAOSqREL1m/zhLF6fX7oIE5eCmbrRA==}
+
+  '@ckeditor/ckeditor5-core@48.4.0':
+    resolution: {integrity: sha512-ck7Y6ekRCSwkJI4KoZMgejs39/1LZmkSUu/dsbdUfKkfBmocNcBeCCKo+x+jGRkQC6NLMdorljMNjtw+1VMvNg==}
+
+  '@ckeditor/ckeditor5-easy-image@48.4.0':
+    resolution: {integrity: sha512-auNm7EdFhr2SOk5E500EiOCvVCXc/+oemoSavSmNqrAvzUpIX4VRGLVjuKVRKA9RPuBv7RO+A0Ye58CQX2Xsig==}
+
+  '@ckeditor/ckeditor5-editor-balloon@48.4.0':
+    resolution: {integrity: sha512-94PR5h6i2CTf9z38VyspjNV40/CWg3tGQ8s6Ve3Sr3Hv3xwif7G3GuF34F2gQHbKugZfTE7lw7NlaiWxf2BBTg==}
+
+  '@ckeditor/ckeditor5-editor-classic@48.4.0':
+    resolution: {integrity: sha512-X6xlcJraajmLm4BxulhcGN722XyAvwGKJo6zrN2SoEK1h9RoEccXJBH+In9i4GThIVch3rrkLlhl6MquGCN6rw==}
+
+  '@ckeditor/ckeditor5-editor-decoupled@48.4.0':
+    resolution: {integrity: sha512-S+sPNOhNil7/3MgmbbPJL/Af1NfzUorTdjOCYVeb2nKOuMqYxOmxr1/xv98Oa06D7MvbpGQQYLgM71xZ+LelMw==}
+
+  '@ckeditor/ckeditor5-editor-inline@48.4.0':
+    resolution: {integrity: sha512-EcuaQOyJNH0dNmf6ani3vU8f0J8uBveX2048IF9cNxBuXrsHM2wX6RG47ohMYLRJdA9PW669MLFOLLdNy1yxYg==}
+
+  '@ckeditor/ckeditor5-editor-multi-root@48.4.0':
+    resolution: {integrity: sha512-YPjNpLiyuro7KKugQQnnVkBRcQVafxR8nwE5BPh6a2iVp75Q+Sr7IE72+RReRPnd0BBcUaM8tG1AuYuer561Lg==}
+
+  '@ckeditor/ckeditor5-emoji@48.4.0':
+    resolution: {integrity: sha512-87DpnxyVOKKcjrQ1cAqkrxdu7/LThMquSexqz+MHVzydJHkr0dFJfLz/TW/1a+4faXC0lmLBonTQLg4hv5UB4w==}
+
+  '@ckeditor/ckeditor5-engine@48.4.0':
+    resolution: {integrity: sha512-279CkhIAHEZ+N3o/XvkWpTtlToMQrjZzFauDAyTjWxNgLdOsrL0JtnhtIaebQUW1Nk5n+1K4CLpPxkdMYobsXw==}
+
+  '@ckeditor/ckeditor5-enter@48.4.0':
+    resolution: {integrity: sha512-Bh5tXfcUVeH1Wao1OSFQJJyvQFHvKwMpZU3rlL9ykXV6Z4eNDsKJe4ZVP0v4jBan0zldWR30JqLiY4aAKq5Wrw==}
+
+  '@ckeditor/ckeditor5-essentials@48.4.0':
+    resolution: {integrity: sha512-wgkZUkF91UkyGIq+uJ5LuuARrXG2okfiON8FRfwCMkmuYKL0md+vVdSOxGKoYmSEQ6RtQDIiXE5ri1XoH3Vyag==}
+
+  '@ckeditor/ckeditor5-find-and-replace@48.4.0':
+    resolution: {integrity: sha512-ORtgvGG5pyQsCWPdO+lX7KARftlRFuYjiscK4Scx3+Ed3T2vLuuF8V162Y3AGUWZxkiZ47JhsCxEnTIIaARB4g==}
+
+  '@ckeditor/ckeditor5-font@48.4.0':
+    resolution: {integrity: sha512-1ZkRknVkHywuIdXWAimU/FfO4DSj8IyhghxGG0hCBwNxVTuLSHZ4wlpKXz0XWjBj0fac2g4SIAKVQfvpcGo8jQ==}
+
+  '@ckeditor/ckeditor5-fullscreen@48.4.0':
+    resolution: {integrity: sha512-cE+W02fiZ5lL2quuikFoJUOuZgp+WDAxPDC9jNGqVYfVxcs6yoTSTmVYNenFp1Fp/kJO5bqev++N3Qj3gf2XCw==}
+
+  '@ckeditor/ckeditor5-heading@48.4.0':
+    resolution: {integrity: sha512-hYTy2MgZ2moznEBgbF3m1zcAe8wKjFCRhHmzoIq8ZaZz7uSZZ5i1hr0LKG8fjUzZl7k57xZbLmfoZNDB5+Ajuw==}
+
+  '@ckeditor/ckeditor5-highlight@48.4.0':
+    resolution: {integrity: sha512-RfcdsdxaOZ3F90tUJMMZyOpdm8SpSEmIBnd4YLRKGgxIziFEAI20wx/6BpLHVLgYzPUi5g6ZqxSB2zwxOxHVTg==}
+
+  '@ckeditor/ckeditor5-horizontal-line@48.4.0':
+    resolution: {integrity: sha512-6jCurKn+5CMNjgOiOVjrvnC1G2+SvhP2YkqNcD+uK3g0PK5dWRnly6HqFyj9RgILI0tFTf/sgaPjoDTS3On6Yw==}
+
+  '@ckeditor/ckeditor5-html-embed@48.4.0':
+    resolution: {integrity: sha512-B385/0dkV9DoN18YQUFcs6zFnPKV5FoVf0CjPP3lCRbjqEU2qZTVHrRtSYBK7Ohykhv+Xc80P9kYDSq81HuiMA==}
+
+  '@ckeditor/ckeditor5-html-support@48.4.0':
+    resolution: {integrity: sha512-Sgj3uir15+kzXkc+EEgt+MBZDCX9ygFQJQodeTpKK3Pi/57Bd0PN9pCOmDRKiH/K16j01BLrn2z07y7HwbxfZA==}
+
+  '@ckeditor/ckeditor5-icons@48.4.0':
+    resolution: {integrity: sha512-5eDe2TYUgiB3rv7807kmm6a7x9nQFvvT70bDE9izI7Ev9TEMoIngYL+c2dVW9BDfw2jpW/qIF9jT4AW21OMP/g==}
+
+  '@ckeditor/ckeditor5-image@48.4.0':
+    resolution: {integrity: sha512-mopPaBUjg7hM8ingQvK5TNlK2ZYWVwH2WM3RWrCRAsI3jWUz2JjuTSKa5nlLRSFMsqJS1yqcCB/trGV9pfQ6xQ==}
+
+  '@ckeditor/ckeditor5-indent@48.4.0':
+    resolution: {integrity: sha512-oGfyhV5UtFeTyZ92aW0spxpQ8cwjmNGC6lHMeIhCycGlAmESuY9zjsHS4fjMHKO5+doorUPeY7x5Gah4G+sQ7g==}
+
+  '@ckeditor/ckeditor5-integrations-common@2.4.1':
+    resolution: {integrity: sha512-DKBMAoKuNWebCFQurX748FP/D8QzfQs7cW5BCJVYRjz0bgbhV33Wj15zKVtByaNLLLOy/fKcYPGHv06KVc4k/Q==}
+    peerDependencies:
+      ckeditor5: '>=42.0.0 || ^0.0.0-nightly'
+
+  '@ckeditor/ckeditor5-language@48.4.0':
+    resolution: {integrity: sha512-ShF6IP/ZYDBVfntwPrUzxTC0c9mqytEUFyZSdJNzf6FPNql4c0YJDIrFQItzaAB+MxAMtac1mNPCEkmdx+Vglw==}
+
+  '@ckeditor/ckeditor5-link@48.4.0':
+    resolution: {integrity: sha512-fRGyVYdmW9fFSe2fawcs3jr+FkXZwIGXRjDYXDSxO2AihwjlIugWLZszkU7SHtilOsUQl/xDWkO/vMfi4GDb8Q==}
+
+  '@ckeditor/ckeditor5-list@48.4.0':
+    resolution: {integrity: sha512-U0cyt1PS0/vf7yllpKUd2cZn7R8H7YVLFYKyyrZK0T9U13swMehF1pXVgonxM1EZMm1Y7COZp7TqHastOdDJlA==}
+
+  '@ckeditor/ckeditor5-markdown-gfm@48.4.0':
+    resolution: {integrity: sha512-Mg8tvoyNK+Lm9sI9i5+jvUntLuVesPc5ceb3x0yIOiPloaMiK8WPthqQBwHNP3vZOHzBra22zaP/OHsp0dLXnA==}
+
+  '@ckeditor/ckeditor5-media-embed@48.4.0':
+    resolution: {integrity: sha512-vgLALayNpVE/9Fp+Kb5qvk3bsvXkw9k3xURWZlb9JsMnOZFUd+jeRe7tQOY4+4UphbxCCqOoYCygte0TCmehSQ==}
+
+  '@ckeditor/ckeditor5-mention@48.4.0':
+    resolution: {integrity: sha512-J96NQAxzy6wIBmKGO7sthGcGryozrt2/C6xF0oMgiYoA+ZGdACFWx2AoCQritnfIRP7APx0P91SZhCd5ZkVQ9g==}
+
+  '@ckeditor/ckeditor5-minimap@48.4.0':
+    resolution: {integrity: sha512-7UOBhAgZ8ymG2teOnEuukpIE+/YSwI0PDHuDIC5FsM5zAK7mD6e11HeYMTKdwRgGRtxf+GTXWEmmbuUvbhQSpQ==}
+
+  '@ckeditor/ckeditor5-page-break@48.4.0':
+    resolution: {integrity: sha512-88yZ0XfsfwFbd+WPmGtz/m5iVoIA3Z6wc3xomg9BGXuaPVPPFtEJ66eDvGVqKdm8hCrOE5yTJ9jrnHqNf3ujKA==}
+
+  '@ckeditor/ckeditor5-paragraph@48.4.0':
+    resolution: {integrity: sha512-KnrkIWVXIz8yOMa+TgmrtEuRaIhxVTpdBCRF9GXHucNIGpxaN3yeRpUdU7CRmtvIaUe4cdltWX4WNf/T/YFIjw==}
+
+  '@ckeditor/ckeditor5-paste-from-office@48.4.0':
+    resolution: {integrity: sha512-+udEzlAbFqquNdVmW0r8yfdbSVprOgkKhK++l/DlLVv81L1lSaizcz36kM4U5/8D/lVYaFDC3ffa368qP7l+jQ==}
+
+  '@ckeditor/ckeditor5-react@11.2.0':
+    resolution: {integrity: sha512-EZrwjyAf8L3p+4E2v3rRb2XMKgFogojla84xmW9LoUyloayurJ1TlifNhmRGmS2paeUGxqRDHjBA0yn+SsTdLg==}
+    peerDependencies:
+      ckeditor5: '>=46.0.0 || ^0.0.0-nightly || ^0.0.0-internal'
+      react: ^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@ckeditor/ckeditor5-remove-format@48.4.0':
+    resolution: {integrity: sha512-fGkcDWbRwLrZc0qmSt+Y8tKDcxEangi5C7LeWrsCfxnmqnCTMoHT11WmRJtnbFv+ZEwbv8InbTpvXLXTa727dQ==}
+
+  '@ckeditor/ckeditor5-restricted-editing@48.4.0':
+    resolution: {integrity: sha512-ryp5H6s0FaTHlyvKiMQgxvXkjkQQEy8N0JhDPjzi6MHxG+9GBkRgLCHAyaGIvDs5vox7F8FLID8zNQre6SqFmA==}
+
+  '@ckeditor/ckeditor5-select-all@48.4.0':
+    resolution: {integrity: sha512-0IUirF/vBHXjDxPyAciEhsKGXLg1KkWyPsFNGluxxvA+W+6thaiBfxFpj9/2mwYit0XiOhb+cbgaKr277h9DyA==}
+
+  '@ckeditor/ckeditor5-show-blocks@48.4.0':
+    resolution: {integrity: sha512-FUqeEXEb5Q6AeX1B+przC/8TaAnuGXKw+N2Zj9roqbZ0+hJiu7PggE0xqlY5GbIzoluxFdGYQKEuFvZb3uY0tQ==}
+
+  '@ckeditor/ckeditor5-source-editing@48.4.0':
+    resolution: {integrity: sha512-OWOcu0MWXwwXK4vzJSBPlgAQOXGTX/Wq9gvrFrji9Pk3YBMECnUzQQV9p1oF9cQay0926vtDgjxsUSi7ue1OYA==}
+
+  '@ckeditor/ckeditor5-special-characters@48.4.0':
+    resolution: {integrity: sha512-ObAHBukAv3WDj/fCT31+lbZ0KzjeJ6dRv9rs/n0kYbtbTukgohhAgDyvKgnO34AoCn5EofkSpZyDATUNqGRVjA==}
+
+  '@ckeditor/ckeditor5-style@48.4.0':
+    resolution: {integrity: sha512-ZGJjCZtdqw2xL2PLV9XOT0oAJnIx8k5UhAJccQ/pgWe6fEKY1W4JrmQvzI6iJ5E4b8qWv0C/L9Z2G3uKwwQUYw==}
+
+  '@ckeditor/ckeditor5-table@48.4.0':
+    resolution: {integrity: sha512-kIVSrHG/F6oy+MBO8W4dRl733jfFlK4okaph5yswsihQujgptN4ndSxovPL5CzocdBE/ueacllWAFakTJ9693g==}
+
+  '@ckeditor/ckeditor5-typing@48.4.0':
+    resolution: {integrity: sha512-vITmUTycz/BxIr/UtXIWlatXvdAbq7Kl6W4bTz3pZaBjqrmmSqABtPvFfgbvH8XDbUND2Qrza6iKxSHU9TbdSQ==}
+
+  '@ckeditor/ckeditor5-ui@48.4.0':
+    resolution: {integrity: sha512-0SQjWIUdXqZmP4WEpjwo9wmYPaigOfNt3gaP3eIeRbkKvF8JZpS8W8W36Q2+dWsw/bc6660aMjyscx66YODXmA==}
+
+  '@ckeditor/ckeditor5-undo@48.4.0':
+    resolution: {integrity: sha512-mi0B58OOwdpvNWBAPgdoyEwSesNoRGdTkpGo/YSjJltg4gAuGQAUr61NJ346oTA+LSmLSlolk11r2RTPQsrcxA==}
+
+  '@ckeditor/ckeditor5-upload@48.4.0':
+    resolution: {integrity: sha512-ljnVJ1BMXz0cE6EC8+PPy5+4wg7dGTtaadyN4RJ6mEL3gEPSjX1hnitSAu24AoRF7tU23rDjec+VBN8by4KxiQ==}
+
+  '@ckeditor/ckeditor5-utils@48.4.0':
+    resolution: {integrity: sha512-7OLdfNXMIVxc2v0ctadymeogka/aH6t5eXPkr+JptdY7lSqWatwIpdI1ZtDEu9CxaTIZRTMa5gSjCow37guA2Q==}
+
+  '@ckeditor/ckeditor5-watchdog@48.4.0':
+    resolution: {integrity: sha512-ZRsf4AK2oSnFxOwZku9WCsIUTXotm98uKOCdO1EYbuhLNOUcQlZYw62hjySlk1qFjI6QB+WQbUIjD89qSVS3WQ==}
+
+  '@ckeditor/ckeditor5-widget@48.4.0':
+    resolution: {integrity: sha512-5/170Ad1V3SdCi0+cr2lXo1OpNTsXIhCMZxGLIDqkLu3IIjpgE8bEdF6hBVNHa9xaztEUOkS7QjkeB/CrYFEBQ==}
+
+  '@ckeditor/ckeditor5-word-count@48.4.0':
+    resolution: {integrity: sha512-xP9/gxknCF9R3F1FiS8HrYWWtvcftUHtXn92XHfvBRBoRHXk2puyrzgLgWVbI8/USBWhX4ek6iuyHmKpLUFhzg==}
 
   '@emotion/is-prop-valid@1.4.0':
     resolution: {integrity: sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==}
@@ -1515,6 +1712,15 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/color-convert@2.0.4':
+    resolution: {integrity: sha512-Ub1MmDdyZ7mX//g25uBAoH/mWGd9swVbt8BseymnaE18SU4po/PjmCrHxqIIRjBo3hV/vh1KGr0eMxUhp+t+dQ==}
+
+  '@types/color-name@1.1.5':
+    resolution: {integrity: sha512-j2K5UJqGTxeesj6oQuGpMgifpT5k9HprgQd8D1Y0lOFqKHl3PJu5GMeS4Y5EgjS55AE6OQxf8mPED9uaGbf4Cg==}
+
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -1524,6 +1730,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -1532,6 +1741,12 @@ packages:
 
   '@types/lodash@4.17.24':
     resolution: {integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
@@ -1546,6 +1761,9 @@ packages:
 
   '@types/resolve@1.20.6':
     resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@typescript-eslint/eslint-plugin@8.57.1':
     resolution: {integrity: sha512-Gn3aqnvNl4NGc6x3/Bqk1AOn0thyTU9bqDRhiRnUWezgvr2OnhYCWCgC8zXXRVqBsIL1pSDt7T9nJUe0oM0kDQ==}
@@ -1605,6 +1823,9 @@ packages:
   '@typescript-eslint/visitor-keys@8.57.1':
     resolution: {integrity: sha512-YWnmJkXbofiz9KbnbbwuA2rpGkFPLbAIetcCNO6mJ8gdhdZ/v7WDXsoGFAJuM6ikUFKTlSQnjWnVO4ux+UzS6A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@ungap/structured-clone@1.3.3':
+    resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
 
   '@vitejs/plugin-react@5.2.0':
     resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
@@ -1721,6 +1942,9 @@ packages:
     peerDependencies:
       styled-components: '>= 2'
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -1732,6 +1956,9 @@ packages:
     resolution: {integrity: sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  blurhash@2.0.5:
+    resolution: {integrity: sha512-cRygWd7kGBQO3VEhPiTgq4Wc43ctsM+o46urrmPOiuAe+07fzlSB9OJVdpgDL0jPqXUVQ9ht7aq7kxOeJHRK+w==}
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
@@ -1771,6 +1998,9 @@ packages:
   caniuse-lite@1.0.30001780:
     resolution: {integrity: sha512-llngX0E7nQci5BPJDqoZSbuZ5Bcs9F5db7EtgfwBerX9XGtkkiO4NwfDDIRzHTTwcYC8vC7bmeUEPGrKlR/TkQ==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
@@ -1779,9 +2009,21 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
+
+  ckeditor5@48.4.0:
+    resolution: {integrity: sha512-q8osuncMcdZVa1IyeeSYC8D9R086m+qUGHGITvmumI0uTS4cDjXLDQ27/G+KP02qMLY4b7U7KM6Tv7wFYTbbNw==}
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
@@ -1798,12 +2040,26 @@ packages:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
 
+  color-convert@3.1.0:
+    resolution: {integrity: sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==}
+    engines: {node: '>=14.6'}
+
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  color-name@2.1.1:
+    resolution: {integrity: sha512-p2FdgwVx1a9yWBHP2wI0VgShkDpgN4kZISkxdNipGBJWpa5G6b04OINlVWCyJj0JmfvcPrgqt95E9k8yvaOJFg==}
+    engines: {node: '>=12.20'}
+
+  color-parse@2.0.2:
+    resolution: {integrity: sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==}
 
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -1854,6 +2110,9 @@ packages:
       supports-color:
         optional: true
 
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
@@ -1895,6 +2154,9 @@ packages:
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -1960,6 +2222,9 @@ packages:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
 
+  es-toolkit@1.45.1:
+    resolution: {integrity: sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==}
+
   esbuild@0.27.4:
     resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
     engines: {node: '>=18'}
@@ -1972,6 +2237,10 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
 
   eslint-config-prettier@10.1.8:
     resolution: {integrity: sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==}
@@ -2044,6 +2313,9 @@ packages:
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -2131,6 +2403,9 @@ packages:
     resolution: {integrity: sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==}
     engines: {node: '>=10'}
 
+  fuzzysort@3.1.0:
+    resolution: {integrity: sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ==}
+
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
     engines: {node: '>= 0.4'}
@@ -2217,6 +2492,48 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hast-util-embedded@3.0.0:
+    resolution: {integrity: sha512-naH8sld4Pe2ep03qqULEtvYr7EjrLK2QHY8KJR6RJkTUjPGObe1vnx585uzem2hGra+s1q08DZZpfgDVYRbaXA==}
+
+  hast-util-from-dom@5.0.1:
+    resolution: {integrity: sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==}
+
+  hast-util-has-property@3.0.0:
+    resolution: {integrity: sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA==}
+
+  hast-util-is-body-ok-link@3.0.1:
+    resolution: {integrity: sha512-0qpnzOBLztXHbHQenVB8uNuxTnm/QBFUOmdOSsEn7GnBtyY07+ENTWVFBAnXd/zEgd9/SUG3lRY7hSIBWRgGpQ==}
+
+  hast-util-is-element@3.0.0:
+    resolution: {integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==}
+
+  hast-util-minify-whitespace@1.0.1:
+    resolution: {integrity: sha512-L96fPOVpnclQE0xzdWb/D12VT5FabA7SnZOUMtL1DbXmYiHJMXZvFkIZfiMmTCNJHUeO2K9UYNXoVyfz+QHuOw==}
+
+  hast-util-parse-selector@4.0.0:
+    resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
+
+  hast-util-phrasing@3.0.1:
+    resolution: {integrity: sha512-6h60VfI3uBQUxHqTyMymMZnEbNl1XmEGtOxxKYL7stY2o601COo62AWAYBQR9lZbYXYSBoxag8UpPRXK+9fqSQ==}
+
+  hast-util-to-dom@4.0.1:
+    resolution: {integrity: sha512-z1VE7sZ8uFzS2baF3LEflX1IPw2gSzrdo3QFEsyoi23MkCVY3FoE9x6nLgOgjwJu8VNWgo+07iaxtONhDzKrUQ==}
+
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
+  hast-util-to-mdast@10.1.2:
+    resolution: {integrity: sha512-FiCRI7NmOvM4y+f5w32jPRzcxDIz+PUqDwEqn1A+1q2cdp3B8Gx7aVrXORdOKjMNDQsD1ogOr896+0jJHW1EFQ==}
+
+  hast-util-to-text@4.0.2:
+    resolution: {integrity: sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  hastscript@9.0.1:
+    resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
+
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
 
@@ -2225,6 +2542,9 @@ packages:
 
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -2329,6 +2649,10 @@ packages:
   is-number-object@1.1.1:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
     engines: {node: '>= 0.4'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
@@ -2524,6 +2848,9 @@ packages:
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -2550,9 +2877,135 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-newline-to-break@2.0.0:
+    resolution: {integrity: sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -2784,6 +3237,9 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  property-information@7.2.0:
+    resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
+
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
@@ -2880,6 +3336,33 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  rehype-dom-parse@5.0.2:
+    resolution: {integrity: sha512-8CqP11KaqvtWsMqVEC2yM3cZWZsDNqqpr8nPvogjraLuh45stabgcpXadCAxu1n6JaUNJ/Xr3GIqXP7okbNqLg==}
+
+  rehype-dom-stringify@4.0.2:
+    resolution: {integrity: sha512-2HVFYbtmm5W3C2j8QsV9lcHdIMc2Yn/ytlPKcSC85/tRx2haZbU8V67Wxyh8STT38ZClvKlZ993Me/Hw8g88Aw==}
+
+  rehype-minify-whitespace@6.0.2:
+    resolution: {integrity: sha512-Zk0pyQ06A3Lyxhe9vGtOtzz3Z0+qZ5+7icZ/PL/2x1SHPbKao5oB/g/rlc6BCTajqBb33JcOe71Ye1oFsuYbnw==}
+
+  rehype-remark@10.0.1:
+    resolution: {integrity: sha512-EmDndlb5NVwXGfUa4c9GPK+lXeItTilLhE6ADSaQuHr4JUlKw9MidzGzx4HpqZrNCt6vnHmEifXQiiA+CEnjYQ==}
+
+  remark-breaks@4.0.0:
+    resolution: {integrity: sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==}
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -2992,6 +3475,9 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
@@ -3027,6 +3513,9 @@ packages:
   string.prototype.trimstart@1.0.8:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
+
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -3104,6 +3593,15 @@ packages:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trim-trailing-lines@2.1.0:
+    resolution: {integrity: sha512-5UR5Biq4VlVOtzqkm2AZlgvSlDJtME46uV0br0gENbwN4l5+mMKT4b9gJKqWtuL2zAIqajGJGuvbCbcAJUZqBg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
@@ -3163,6 +3661,27 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-find-after@5.0.0:
+    resolution: {integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.0.0:
+    resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
+
   unplugin@2.3.11:
     resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
     engines: {node: '>=18.12.0'}
@@ -3200,6 +3719,15 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  vanilla-colorful@0.7.2:
+    resolution: {integrity: sha512-z2YZusTFC6KnLERx1cgoIRX2CjPRP0W75N+3CC6gbvdX5Ch47rZkEMGO2Xnf+IEmi3RiFLxS18gayMA27iU7Kg==}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite-plugin-full-reload@1.2.0:
     resolution: {integrity: sha512-kz18NW79x0IHbxRSHm0jttP4zoO9P9gXh+n6UTwlNKnviTTEpOlum6oS9SmecrTtSr+muHEn5TUuC75UovQzcA==}
@@ -3243,6 +3771,9 @@ packages:
         optional: true
       yaml:
         optional: true
+
+  web-namespaces@2.0.1:
+    resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
@@ -3319,6 +3850,9 @@ packages:
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -3446,6 +3980,562 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@ckeditor/ckeditor5-adapter-ckfinder@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-upload': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+
+  '@ckeditor/ckeditor5-alignment@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-icons': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+
+  '@ckeditor/ckeditor5-autoformat@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-heading': 48.4.0
+      '@ckeditor/ckeditor5-typing': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+
+  '@ckeditor/ckeditor5-autosave@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+      es-toolkit: 1.45.1
+
+  '@ckeditor/ckeditor5-basic-styles@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-icons': 48.4.0
+      '@ckeditor/ckeditor5-typing': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+
+  '@ckeditor/ckeditor5-block-quote@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-enter': 48.4.0
+      '@ckeditor/ckeditor5-icons': 48.4.0
+      '@ckeditor/ckeditor5-typing': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+
+  '@ckeditor/ckeditor5-bookmark@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-icons': 48.4.0
+      '@ckeditor/ckeditor5-link': 48.4.0
+      '@ckeditor/ckeditor5-typing': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+      '@ckeditor/ckeditor5-widget': 48.4.0
+
+  '@ckeditor/ckeditor5-ckbox@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-cloud-services': 48.4.0
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-icons': 48.4.0
+      '@ckeditor/ckeditor5-image': 48.4.0
+      '@ckeditor/ckeditor5-link': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-upload': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+      blurhash: 2.0.5
+      es-toolkit: 1.45.1
+
+  '@ckeditor/ckeditor5-ckfinder@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-adapter-ckfinder': 48.4.0
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-icons': 48.4.0
+      '@ckeditor/ckeditor5-image': 48.4.0
+      '@ckeditor/ckeditor5-link': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+
+  '@ckeditor/ckeditor5-clipboard@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+      '@ckeditor/ckeditor5-widget': 48.4.0
+      es-toolkit: 1.45.1
+
+  '@ckeditor/ckeditor5-cloud-services@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-upload': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+
+  '@ckeditor/ckeditor5-code-block@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-clipboard': 48.4.0
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-enter': 48.4.0
+      '@ckeditor/ckeditor5-icons': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+
+  '@ckeditor/ckeditor5-core@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+      '@ckeditor/ckeditor5-watchdog': 48.4.0
+      es-toolkit: 1.45.1
+
+  '@ckeditor/ckeditor5-easy-image@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-cloud-services': 48.4.0
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-image': 48.4.0
+      '@ckeditor/ckeditor5-upload': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+
+  '@ckeditor/ckeditor5-editor-balloon@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+      es-toolkit: 1.45.1
+
+  '@ckeditor/ckeditor5-editor-classic@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+      es-toolkit: 1.45.1
+
+  '@ckeditor/ckeditor5-editor-decoupled@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+      es-toolkit: 1.45.1
+
+  '@ckeditor/ckeditor5-editor-inline@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+      es-toolkit: 1.45.1
+
+  '@ckeditor/ckeditor5-editor-multi-root@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+      es-toolkit: 1.45.1
+
+  '@ckeditor/ckeditor5-emoji@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-icons': 48.4.0
+      '@ckeditor/ckeditor5-mention': 48.4.0
+      '@ckeditor/ckeditor5-typing': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+      es-toolkit: 1.45.1
+      fuzzysort: 3.1.0
+
+  '@ckeditor/ckeditor5-engine@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-utils': 48.4.0
+      es-toolkit: 1.45.1
+
+  '@ckeditor/ckeditor5-enter@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+
+  '@ckeditor/ckeditor5-essentials@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-clipboard': 48.4.0
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-enter': 48.4.0
+      '@ckeditor/ckeditor5-select-all': 48.4.0
+      '@ckeditor/ckeditor5-typing': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-undo': 48.4.0
+
+  '@ckeditor/ckeditor5-find-and-replace@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-icons': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+      es-toolkit: 1.45.1
+
+  '@ckeditor/ckeditor5-font@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-icons': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+
+  '@ckeditor/ckeditor5-fullscreen@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-editor-classic': 48.4.0
+      '@ckeditor/ckeditor5-editor-decoupled': 48.4.0
+      '@ckeditor/ckeditor5-icons': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+
+  '@ckeditor/ckeditor5-heading@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-enter': 48.4.0
+      '@ckeditor/ckeditor5-icons': 48.4.0
+      '@ckeditor/ckeditor5-paragraph': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+
+  '@ckeditor/ckeditor5-highlight@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-icons': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+
+  '@ckeditor/ckeditor5-horizontal-line@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-icons': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+      '@ckeditor/ckeditor5-widget': 48.4.0
+
+  '@ckeditor/ckeditor5-html-embed@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-icons': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+      '@ckeditor/ckeditor5-widget': 48.4.0
+
+  '@ckeditor/ckeditor5-html-support@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-clipboard': 48.4.0
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-enter': 48.4.0
+      '@ckeditor/ckeditor5-heading': 48.4.0
+      '@ckeditor/ckeditor5-image': 48.4.0
+      '@ckeditor/ckeditor5-list': 48.4.0
+      '@ckeditor/ckeditor5-remove-format': 48.4.0
+      '@ckeditor/ckeditor5-table': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+      '@ckeditor/ckeditor5-widget': 48.4.0
+      es-toolkit: 1.45.1
+
+  '@ckeditor/ckeditor5-icons@48.4.0': {}
+
+  '@ckeditor/ckeditor5-image@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-clipboard': 48.4.0
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-icons': 48.4.0
+      '@ckeditor/ckeditor5-typing': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-undo': 48.4.0
+      '@ckeditor/ckeditor5-upload': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+      '@ckeditor/ckeditor5-widget': 48.4.0
+      es-toolkit: 1.45.1
+
+  '@ckeditor/ckeditor5-indent@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-heading': 48.4.0
+      '@ckeditor/ckeditor5-icons': 48.4.0
+      '@ckeditor/ckeditor5-list': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+
+  '@ckeditor/ckeditor5-integrations-common@2.4.1(ckeditor5@48.4.0)':
+    dependencies:
+      ckeditor5: 48.4.0
+
+  '@ckeditor/ckeditor5-language@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+
+  '@ckeditor/ckeditor5-link@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-clipboard': 48.4.0
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-enter': 48.4.0
+      '@ckeditor/ckeditor5-icons': 48.4.0
+      '@ckeditor/ckeditor5-image': 48.4.0
+      '@ckeditor/ckeditor5-typing': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+      '@ckeditor/ckeditor5-widget': 48.4.0
+      es-toolkit: 1.45.1
+
+  '@ckeditor/ckeditor5-list@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-clipboard': 48.4.0
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-enter': 48.4.0
+      '@ckeditor/ckeditor5-font': 48.4.0
+      '@ckeditor/ckeditor5-icons': 48.4.0
+      '@ckeditor/ckeditor5-typing': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+      es-toolkit: 1.45.1
+
+  '@ckeditor/ckeditor5-markdown-gfm@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-clipboard': 48.4.0
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@types/hast': 3.0.4
+      hast-util-from-dom: 5.0.1
+      hast-util-to-html: 9.0.5
+      hast-util-to-mdast: 10.1.2
+      hastscript: 9.0.1
+      rehype-dom-parse: 5.0.2
+      rehype-dom-stringify: 4.0.2
+      rehype-remark: 10.0.1
+      remark-breaks: 4.0.0
+      remark-gfm: 4.0.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+      unist-util-visit: 5.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@ckeditor/ckeditor5-media-embed@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-clipboard': 48.4.0
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-icons': 48.4.0
+      '@ckeditor/ckeditor5-typing': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-undo': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+      '@ckeditor/ckeditor5-widget': 48.4.0
+
+  '@ckeditor/ckeditor5-mention@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-typing': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+      es-toolkit: 1.45.1
+
+  '@ckeditor/ckeditor5-minimap@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+
+  '@ckeditor/ckeditor5-page-break@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-icons': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+      '@ckeditor/ckeditor5-widget': 48.4.0
+
+  '@ckeditor/ckeditor5-paragraph@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-icons': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+
+  '@ckeditor/ckeditor5-paste-from-office@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-clipboard': 48.4.0
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+
+  '@ckeditor/ckeditor5-react@11.2.0(ckeditor5@48.4.0)(react@19.2.4)':
+    dependencies:
+      '@ckeditor/ckeditor5-integrations-common': 2.4.1(ckeditor5@48.4.0)
+      ckeditor5: 48.4.0
+      react: 19.2.4
+
+  '@ckeditor/ckeditor5-remove-format@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-icons': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+
+  '@ckeditor/ckeditor5-restricted-editing@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-clipboard': 48.4.0
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-icons': 48.4.0
+      '@ckeditor/ckeditor5-typing': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+
+  '@ckeditor/ckeditor5-select-all@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-icons': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+
+  '@ckeditor/ckeditor5-show-blocks@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-icons': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+
+  '@ckeditor/ckeditor5-source-editing@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-icons': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+
+  '@ckeditor/ckeditor5-special-characters@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-icons': 48.4.0
+      '@ckeditor/ckeditor5-typing': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+
+  '@ckeditor/ckeditor5-style@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-html-support': 48.4.0
+      '@ckeditor/ckeditor5-list': 48.4.0
+      '@ckeditor/ckeditor5-table': 48.4.0
+      '@ckeditor/ckeditor5-typing': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+      es-toolkit: 1.45.1
+
+  '@ckeditor/ckeditor5-table@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-clipboard': 48.4.0
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-enter': 48.4.0
+      '@ckeditor/ckeditor5-icons': 48.4.0
+      '@ckeditor/ckeditor5-typing': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+      '@ckeditor/ckeditor5-widget': 48.4.0
+      es-toolkit: 1.45.1
+
+  '@ckeditor/ckeditor5-typing@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+      es-toolkit: 1.45.1
+
+  '@ckeditor/ckeditor5-ui@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-editor-multi-root': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-icons': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+      '@types/color-convert': 2.0.4
+      color-convert: 3.1.0
+      color-parse: 2.0.2
+      es-toolkit: 1.45.1
+      vanilla-colorful: 0.7.2
+
+  '@ckeditor/ckeditor5-undo@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-icons': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+
+  '@ckeditor/ckeditor5-upload@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+
+  '@ckeditor/ckeditor5-utils@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      es-toolkit: 1.45.1
+
+  '@ckeditor/ckeditor5-watchdog@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+      es-toolkit: 1.45.1
+
+  '@ckeditor/ckeditor5-widget@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-enter': 48.4.0
+      '@ckeditor/ckeditor5-icons': 48.4.0
+      '@ckeditor/ckeditor5-typing': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+      es-toolkit: 1.45.1
+
+  '@ckeditor/ckeditor5-word-count@48.4.0':
+    dependencies:
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+      es-toolkit: 1.45.1
 
   '@emotion/is-prop-valid@1.4.0':
     dependencies:
@@ -4556,11 +5646,25 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/color-convert@2.0.4':
+    dependencies:
+      '@types/color-name': 1.1.5
+
+  '@types/color-name@1.1.5': {}
+
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/doctrine@0.0.9': {}
 
   '@types/estree@1.0.8': {}
+
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
 
   '@types/json-schema@7.0.15': {}
 
@@ -4569,6 +5673,12 @@ snapshots:
       '@types/lodash': 4.17.24
 
   '@types/lodash@4.17.24': {}
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@22.19.15':
     dependencies:
@@ -4583,6 +5693,8 @@ snapshots:
       csstype: 3.2.3
 
   '@types/resolve@1.20.6': {}
+
+  '@types/unist@3.0.3': {}
 
   '@typescript-eslint/eslint-plugin@8.57.1(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -4674,6 +5786,8 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.57.1
       eslint-visitor-keys: 5.0.1
+
+  '@ungap/structured-clone@1.3.3': {}
 
   '@vitejs/plugin-react@5.2.0(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0))':
     dependencies:
@@ -4837,11 +5951,15 @@ snapshots:
       - '@babel/core'
       - supports-color
 
+  bail@2.0.2: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.8: {}
+
+  blurhash@2.0.5: {}
 
   brace-expansion@1.1.12:
     dependencies:
@@ -4887,6 +6005,8 @@ snapshots:
 
   caniuse-lite@1.0.30001780: {}
 
+  ccount@2.0.1: {}
+
   chai@5.3.3:
     dependencies:
       assertion-error: 2.0.1
@@ -4900,7 +6020,78 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
   check-error@2.1.3: {}
+
+  ckeditor5@48.4.0:
+    dependencies:
+      '@ckeditor/ckeditor5-adapter-ckfinder': 48.4.0
+      '@ckeditor/ckeditor5-alignment': 48.4.0
+      '@ckeditor/ckeditor5-autoformat': 48.4.0
+      '@ckeditor/ckeditor5-autosave': 48.4.0
+      '@ckeditor/ckeditor5-basic-styles': 48.4.0
+      '@ckeditor/ckeditor5-block-quote': 48.4.0
+      '@ckeditor/ckeditor5-bookmark': 48.4.0
+      '@ckeditor/ckeditor5-ckbox': 48.4.0
+      '@ckeditor/ckeditor5-ckfinder': 48.4.0
+      '@ckeditor/ckeditor5-clipboard': 48.4.0
+      '@ckeditor/ckeditor5-cloud-services': 48.4.0
+      '@ckeditor/ckeditor5-code-block': 48.4.0
+      '@ckeditor/ckeditor5-core': 48.4.0
+      '@ckeditor/ckeditor5-easy-image': 48.4.0
+      '@ckeditor/ckeditor5-editor-balloon': 48.4.0
+      '@ckeditor/ckeditor5-editor-classic': 48.4.0
+      '@ckeditor/ckeditor5-editor-decoupled': 48.4.0
+      '@ckeditor/ckeditor5-editor-inline': 48.4.0
+      '@ckeditor/ckeditor5-editor-multi-root': 48.4.0
+      '@ckeditor/ckeditor5-emoji': 48.4.0
+      '@ckeditor/ckeditor5-engine': 48.4.0
+      '@ckeditor/ckeditor5-enter': 48.4.0
+      '@ckeditor/ckeditor5-essentials': 48.4.0
+      '@ckeditor/ckeditor5-find-and-replace': 48.4.0
+      '@ckeditor/ckeditor5-font': 48.4.0
+      '@ckeditor/ckeditor5-fullscreen': 48.4.0
+      '@ckeditor/ckeditor5-heading': 48.4.0
+      '@ckeditor/ckeditor5-highlight': 48.4.0
+      '@ckeditor/ckeditor5-horizontal-line': 48.4.0
+      '@ckeditor/ckeditor5-html-embed': 48.4.0
+      '@ckeditor/ckeditor5-html-support': 48.4.0
+      '@ckeditor/ckeditor5-icons': 48.4.0
+      '@ckeditor/ckeditor5-image': 48.4.0
+      '@ckeditor/ckeditor5-indent': 48.4.0
+      '@ckeditor/ckeditor5-language': 48.4.0
+      '@ckeditor/ckeditor5-link': 48.4.0
+      '@ckeditor/ckeditor5-list': 48.4.0
+      '@ckeditor/ckeditor5-markdown-gfm': 48.4.0
+      '@ckeditor/ckeditor5-media-embed': 48.4.0
+      '@ckeditor/ckeditor5-mention': 48.4.0
+      '@ckeditor/ckeditor5-minimap': 48.4.0
+      '@ckeditor/ckeditor5-page-break': 48.4.0
+      '@ckeditor/ckeditor5-paragraph': 48.4.0
+      '@ckeditor/ckeditor5-paste-from-office': 48.4.0
+      '@ckeditor/ckeditor5-remove-format': 48.4.0
+      '@ckeditor/ckeditor5-restricted-editing': 48.4.0
+      '@ckeditor/ckeditor5-select-all': 48.4.0
+      '@ckeditor/ckeditor5-show-blocks': 48.4.0
+      '@ckeditor/ckeditor5-source-editing': 48.4.0
+      '@ckeditor/ckeditor5-special-characters': 48.4.0
+      '@ckeditor/ckeditor5-style': 48.4.0
+      '@ckeditor/ckeditor5-table': 48.4.0
+      '@ckeditor/ckeditor5-typing': 48.4.0
+      '@ckeditor/ckeditor5-ui': 48.4.0
+      '@ckeditor/ckeditor5-undo': 48.4.0
+      '@ckeditor/ckeditor5-upload': 48.4.0
+      '@ckeditor/ckeditor5-utils': 48.4.0
+      '@ckeditor/ckeditor5-watchdog': 48.4.0
+      '@ckeditor/ckeditor5-widget': 48.4.0
+      '@ckeditor/ckeditor5-word-count': 48.4.0
+    transitivePeerDependencies:
+      - supports-color
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -4918,11 +6109,23 @@ snapshots:
     dependencies:
       color-name: 1.1.4
 
+  color-convert@3.1.0:
+    dependencies:
+      color-name: 2.1.1
+
   color-name@1.1.4: {}
+
+  color-name@2.1.1: {}
+
+  color-parse@2.0.2:
+    dependencies:
+      color-name: 2.1.1
 
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+
+  comma-separated-tokens@2.0.3: {}
 
   concat-map@0.0.1: {}
 
@@ -4979,6 +6182,10 @@ snapshots:
     optionalDependencies:
       supports-color: 5.5.0
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   deep-eql@5.0.2: {}
 
   deep-is@0.1.4: {}
@@ -5011,6 +6218,10 @@ snapshots:
   detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   doctrine@2.1.0:
     dependencies:
@@ -5143,6 +6354,8 @@ snapshots:
       is-date-object: 1.1.0
       is-symbol: 1.1.1
 
+  es-toolkit@1.45.1: {}
+
   esbuild@0.27.4:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.27.4
@@ -5175,6 +6388,8 @@ snapshots:
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
+
+  escape-string-regexp@5.0.0: {}
 
   eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
@@ -5287,6 +6502,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  extend@3.0.2: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-equals@2.0.4: {}
@@ -5356,6 +6573,8 @@ snapshots:
   functions-have-names@1.2.3: {}
 
   fuse.js@6.6.2: {}
+
+  fuzzysort@3.1.0: {}
 
   generator-function@2.0.1: {}
 
@@ -5436,6 +6655,105 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-embedded@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-is-element: 3.0.0
+
+  hast-util-from-dom@5.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hastscript: 9.0.1
+      web-namespaces: 2.0.1
+
+  hast-util-has-property@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-is-body-ok-link@3.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-is-element@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-minify-whitespace@1.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-embedded: 3.0.0
+      hast-util-is-element: 3.0.0
+      hast-util-whitespace: 3.0.0
+      unist-util-is: 6.0.1
+
+  hast-util-parse-selector@4.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-phrasing@3.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-embedded: 3.0.0
+      hast-util-has-property: 3.0.0
+      hast-util-is-body-ok-link: 3.0.1
+      hast-util-is-element: 3.0.0
+
+  hast-util-to-dom@4.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      property-information: 7.2.0
+      web-namespaces: 2.0.1
+
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
+  hast-util-to-mdast@10.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.3
+      hast-util-phrasing: 3.0.1
+      hast-util-to-html: 9.0.5
+      hast-util-to-text: 4.0.2
+      hast-util-whitespace: 3.0.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-hast: 13.2.1
+      mdast-util-to-string: 4.0.0
+      rehype-minify-whitespace: 6.0.2
+      trim-trailing-lines: 2.1.0
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.0.0
+
+  hast-util-to-text@4.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      hast-util-is-element: 3.0.0
+      unist-util-find-after: 5.0.0
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hastscript@9.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      hast-util-parse-selector: 4.0.0
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+
   hermes-estree@0.25.1: {}
 
   hermes-parser@0.25.1:
@@ -5445,6 +6763,8 @@ snapshots:
   hoist-non-react-statics@3.3.2:
     dependencies:
       react-is: 16.13.1
+
+  html-void-elements@3.0.0: {}
 
   ignore@5.3.2: {}
 
@@ -5544,6 +6864,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
+
+  is-plain-obj@4.1.0: {}
 
   is-regex@1.2.1:
     dependencies:
@@ -5720,6 +7042,8 @@ snapshots:
 
   lodash@4.17.23: {}
 
+  longest-streak@3.1.0: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -5742,7 +7066,319 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  markdown-table@3.0.4: {}
+
   math-intrinsics@1.1.0: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-newline-to-break@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-find-and-replace: 3.0.2
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.3
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.0.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.0.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3(supports-color@5.5.0)
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   mime-db@1.52.0: {}
 
@@ -5911,6 +7547,8 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  property-information@7.2.0: {}
+
   proxy-from-env@1.1.0: {}
 
   punycode@2.3.1: {}
@@ -6021,6 +7659,71 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  rehype-dom-parse@5.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-from-dom: 5.0.1
+      unified: 11.0.5
+
+  rehype-dom-stringify@4.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-to-dom: 4.0.1
+      unified: 11.0.5
+
+  rehype-minify-whitespace@6.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-minify-whitespace: 1.0.1
+
+  rehype-remark@10.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      hast-util-to-mdast: 10.1.2
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  remark-breaks@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-newline-to-break: 2.0.0
+      unified: 11.0.5
+
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   require-directory@2.1.1: {}
 
@@ -6172,6 +7875,8 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  space-separated-tokens@2.0.2: {}
+
   stop-iteration-iterator@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -6250,6 +7955,11 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -6316,6 +8026,12 @@ snapshots:
   tinyspy@4.0.4: {}
 
   tree-kill@1.2.2: {}
+
+  trim-lines@3.0.1: {}
+
+  trim-trailing-lines@2.1.0: {}
+
+  trough@2.2.0: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
@@ -6392,6 +8108,44 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-find-after@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   unplugin@2.3.11:
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -6428,6 +8182,18 @@ snapshots:
     dependencies:
       react: 19.2.4
 
+  vanilla-colorful@0.7.2: {}
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
+
   vite-plugin-full-reload@1.2.0:
     dependencies:
       picocolors: 1.1.1
@@ -6446,6 +8212,8 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.32.0
+
+  web-namespaces@2.0.1: {}
 
   webpack-virtual-modules@0.6.2: {}
 
@@ -6531,3 +8299,5 @@ snapshots:
       zod: 4.3.6
 
   zod@4.3.6: {}
+
+  zwitch@2.0.4: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,0 @@
-allowBuilds:
-  esbuild: true

--- a/resources/js/elements/dept-portal/DeptPatientForm.tsx
+++ b/resources/js/elements/dept-portal/DeptPatientForm.tsx
@@ -1677,32 +1677,40 @@ export default function DeptPatientForm({
                                     </>
                                 )}
                             </div>
-                            {!requireDischargeDetails && outcome === 'referred' && (
-                                <div className="mt-3">
-                                    <label className="mb-1 block text-xs font-medium text-slate-500">
-                                        Referral Letter Notes
-                                    </label>
-                                    <Suspense
-                                        fallback={
-                                            <div className="flex h-[180px] items-center justify-center rounded-lg border border-slate-200 text-xs text-slate-400">
-                                                Loading editor…
-                                            </div>
-                                        }
-                                    >
-                                        <ReferralNotesEditor
-                                            value={referralNotes}
-                                            onChange={setReferralNotes}
-                                            disabled={isFinalized}
-                                        />
-                                    </Suspense>
-                                    <p className="mt-1 text-[11px] text-slate-400">
-                                        Type <span className="font-mono">#</span> for a drug,{' '}
-                                        <span className="font-mono">@</span> for a doctor,{' '}
-                                        <span className="font-mono">&amp;</span> for an ICD-10 code, or{' '}
-                                        <span className="font-mono">!</span> for a closing/transaction number.
-                                    </p>
-                                </div>
-                            )}
+                            {!requireDischargeDetails &&
+                                outcome === 'referred' && (
+                                    <div className="mt-3">
+                                        <label className="mb-1 block text-xs font-medium text-slate-500">
+                                            Referral Letter Notes
+                                        </label>
+                                        <Suspense
+                                            fallback={
+                                                <div className="flex h-[180px] items-center justify-center rounded-lg border border-slate-200 text-xs text-slate-400">
+                                                    Loading editor…
+                                                </div>
+                                            }
+                                        >
+                                            <ReferralNotesEditor
+                                                value={referralNotes}
+                                                onChange={setReferralNotes}
+                                                disabled={isFinalized}
+                                            />
+                                        </Suspense>
+                                        <p className="mt-1 text-[11px] text-slate-400">
+                                            Type{' '}
+                                            <span className="font-mono">#</span>{' '}
+                                            for a drug,{' '}
+                                            <span className="font-mono">@</span>{' '}
+                                            for a doctor,{' '}
+                                            <span className="font-mono">
+                                                &amp;
+                                            </span>{' '}
+                                            for an ICD-10 code, or{' '}
+                                            <span className="font-mono">!</span>{' '}
+                                            for a closing/transaction number.
+                                        </p>
+                                    </div>
+                                )}
                             {requireDischargeDetails && outcome && (
                                 <div className="mt-3 rounded-xl border border-slate-100 bg-slate-50 px-3 py-2 text-xs text-slate-600">
                                     Disposition recorded via Discharge:{' '}

--- a/resources/js/elements/dept-portal/DeptPatientForm.tsx
+++ b/resources/js/elements/dept-portal/DeptPatientForm.tsx
@@ -45,8 +45,14 @@ import {
     Wind,
     X,
 } from 'lucide-react';
-import { useCallback, useState } from 'react';
+import { lazy, Suspense, useCallback, useState } from 'react';
 import { toast } from 'sonner';
+
+// CKEditor5 adds ~700KB to this chunk — lazy-load it so departments/visits
+// that never hit outcome === 'referred' don't pay that cost upfront.
+const ReferralNotesEditor = lazy(
+    () => import('@/elements/dept-portal/ReferralNotesEditor'),
+);
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -368,6 +374,7 @@ export default function DeptPatientForm({
         existing?.outcome_notes ?? '',
     );
     const [referralTo, setReferralTo] = useState(existing?.referral_to ?? '');
+    const [referralNotes, setReferralNotes] = useState('');
     const [examFindings, setExamFindings] = useState<Record<string, string>>(
         existing?.examination_findings ?? {},
     );
@@ -441,6 +448,11 @@ export default function DeptPatientForm({
                 showFollowUp || requireDischargeDetails
                     ? referralTo || null
                     : null,
+            referral_notes:
+                (showFollowUp || requireDischargeDetails) &&
+                outcome === 'referred'
+                    ? referralNotes || null
+                    : null,
             vitals:
                 showVitals && Object.values(vitals).some((v) => v !== '')
                     ? vitals
@@ -472,6 +484,7 @@ export default function DeptPatientForm({
             outcomeAt,
             outcomeNotes,
             referralTo,
+            referralNotes,
             vitals,
             dentalChart,
             triageId,
@@ -1664,6 +1677,32 @@ export default function DeptPatientForm({
                                     </>
                                 )}
                             </div>
+                            {!requireDischargeDetails && outcome === 'referred' && (
+                                <div className="mt-3">
+                                    <label className="mb-1 block text-xs font-medium text-slate-500">
+                                        Referral Letter Notes
+                                    </label>
+                                    <Suspense
+                                        fallback={
+                                            <div className="flex h-[180px] items-center justify-center rounded-lg border border-slate-200 text-xs text-slate-400">
+                                                Loading editor…
+                                            </div>
+                                        }
+                                    >
+                                        <ReferralNotesEditor
+                                            value={referralNotes}
+                                            onChange={setReferralNotes}
+                                            disabled={isFinalized}
+                                        />
+                                    </Suspense>
+                                    <p className="mt-1 text-[11px] text-slate-400">
+                                        Type <span className="font-mono">#</span> for a drug,{' '}
+                                        <span className="font-mono">@</span> for a doctor,{' '}
+                                        <span className="font-mono">&amp;</span> for an ICD-10 code, or{' '}
+                                        <span className="font-mono">!</span> for a closing/transaction number.
+                                    </p>
+                                </div>
+                            )}
                             {requireDischargeDetails && outcome && (
                                 <div className="mt-3 rounded-xl border border-slate-100 bg-slate-50 px-3 py-2 text-xs text-slate-600">
                                     Disposition recorded via Discharge:{' '}

--- a/resources/js/elements/dept-portal/ReferralNotesEditor.tsx
+++ b/resources/js/elements/dept-portal/ReferralNotesEditor.tsx
@@ -1,0 +1,182 @@
+import { apiClosingsSearch, apiDrugsSearch, apiIcd10Codes, apiUsersSearch } from '@/routes';
+import { CKEditor } from '@ckeditor/ckeditor5-react';
+import {
+    Bold,
+    ClassicEditor,
+    Essentials,
+    Italic,
+    List,
+    Mention,
+    Paragraph,
+    Underline,
+    type MentionFeedObjectItem,
+} from 'ckeditor5';
+import 'ckeditor5/ckeditor5.css';
+
+// Mention feed markers:
+//   #  drug            (reuses /api/drugs/search)
+//   @  doctor          (reuses /api/users/search, doctor_only=true)
+//   &  ICD-10 code      (reuses /api/icd10-codes)
+//   !  closing/transaction number (reuses /api/closings/search)
+
+function getCsrf() {
+    return decodeURIComponent(
+        document.cookie.split('XSRF-TOKEN=')[1]?.split(';')[0] ?? '',
+    );
+}
+
+interface MentionItem extends MentionFeedObjectItem {
+    label: string;
+    detail?: string;
+}
+
+async function fetchJson(url: string, init?: RequestInit) {
+    try {
+        const res = await fetch(url, {
+            ...init,
+            headers: {
+                Accept: 'application/json',
+                'X-Requested-With': 'XMLHttpRequest',
+                ...(init?.headers ?? {}),
+            },
+        });
+        if (!res.ok) return null;
+        return await res.json();
+    } catch {
+        return null;
+    }
+}
+
+async function drugFeed(queryText: string): Promise<MentionItem[]> {
+    const json = await fetchJson(
+        `${apiDrugsSearch().url}?q=${encodeURIComponent(queryText)}&limit=10`,
+    );
+    return (json?.data ?? []).map(
+        (drug: { name: string; generic_name?: string }) => ({
+            id: `#${drug.name}`,
+            label: drug.name,
+            detail: drug.generic_name,
+        }),
+    );
+}
+
+async function doctorFeed(queryText: string): Promise<MentionItem[]> {
+    const json = await fetchJson(apiUsersSearch().url, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'X-XSRF-TOKEN': getCsrf(),
+        },
+        body: JSON.stringify({ name: queryText, doctor_only: true, limit: 10 }),
+    });
+    const exact = json?.data?.exact ?? [];
+    const possible = json?.data?.possible ?? [];
+    const seen = new Set<number>();
+    return [...exact, ...possible]
+        .filter((user: { id: number }) => {
+            if (seen.has(user.id)) return false;
+            seen.add(user.id);
+            return true;
+        })
+        .map((user: { name: string }) => ({ id: `@${user.name}`, label: user.name }));
+}
+
+async function icdFeed(queryText: string): Promise<MentionItem[]> {
+    const json = await fetchJson(
+        `${apiIcd10Codes().url}?q=${encodeURIComponent(queryText)}`,
+    );
+    return (json?.data ?? []).map(
+        (icd: { code: string; description?: string }) => ({
+            id: `&${icd.code}`,
+            label: icd.code,
+            detail: icd.description,
+        }),
+    );
+}
+
+async function closingFeed(queryText: string): Promise<MentionItem[]> {
+    const json = await fetchJson(apiClosingsSearch().url, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'X-XSRF-TOKEN': getCsrf(),
+        },
+        body: JSON.stringify({ search: queryText, limit: 10 }),
+    });
+    return (json?.data ?? []).map((closing: { ct_number: string }) => ({
+        id: `!${closing.ct_number}`,
+        label: closing.ct_number,
+    }));
+}
+
+function renderMentionItem(feedItem: MentionFeedObjectItem): HTMLElement {
+    // itemRenderer is typed against the base MentionFeedObjectItem (id/text
+    // only), but the feed functions above always populate MentionItem's
+    // extra label/detail fields — safe to assume here.
+    const item = feedItem as MentionItem;
+
+    const wrapper = document.createElement('span');
+    wrapper.style.display = 'flex';
+    wrapper.style.flexDirection = 'column';
+    wrapper.style.padding = '2px 4px';
+
+    const label = document.createElement('span');
+    label.style.fontWeight = '600';
+    label.textContent = item.label;
+    wrapper.appendChild(label);
+
+    if (item.detail) {
+        const detail = document.createElement('span');
+        detail.style.fontSize = '11px';
+        detail.style.color = '#64748b';
+        detail.textContent = item.detail;
+        wrapper.appendChild(detail);
+    }
+
+    return wrapper;
+}
+
+interface ReferralNotesEditorProps {
+    value: string;
+    onChange: (html: string) => void;
+    disabled?: boolean;
+}
+
+export default function ReferralNotesEditor({
+    value,
+    onChange,
+    disabled = false,
+}: ReferralNotesEditorProps) {
+    return (
+        <div className="rounded-lg border border-slate-200 [&_.ck-editor__editable]:min-h-[140px] [&_.ck-editor__editable]:px-3 [&_.ck-editor__editable]:py-2">
+            <CKEditor
+                editor={ClassicEditor}
+                disabled={disabled}
+                data={value}
+                onChange={(_event, editor) => onChange(editor.getData())}
+                config={{
+                    licenseKey: 'GPL',
+                    plugins: [Essentials, Paragraph, Bold, Italic, Underline, List, Mention],
+                    toolbar: [
+                        'bold',
+                        'italic',
+                        'underline',
+                        'bulletedList',
+                        'numberedList',
+                        '|',
+                        'undo',
+                        'redo',
+                    ],
+                    mention: {
+                        feeds: [
+                            { marker: '#', feed: drugFeed, itemRenderer: renderMentionItem, minimumCharacters: 1 },
+                            { marker: '@', feed: doctorFeed, itemRenderer: renderMentionItem, minimumCharacters: 1 },
+                            { marker: '&', feed: icdFeed, itemRenderer: renderMentionItem, minimumCharacters: 1 },
+                            { marker: '!', feed: closingFeed, itemRenderer: renderMentionItem, minimumCharacters: 1 },
+                        ],
+                    },
+                }}
+            />
+        </div>
+    );
+}

--- a/resources/js/elements/dept-portal/ReferralNotesEditor.tsx
+++ b/resources/js/elements/dept-portal/ReferralNotesEditor.tsx
@@ -1,4 +1,9 @@
-import { apiClosingsSearch, apiDrugsSearch, apiIcd10Codes, apiUsersSearch } from '@/routes';
+import {
+    apiClosingsSearch,
+    apiDrugsSearch,
+    apiIcd10Codes,
+    apiUsersSearch,
+} from '@/routes';
 import { CKEditor } from '@ckeditor/ckeditor5-react';
 import {
     Bold,
@@ -78,7 +83,10 @@ async function doctorFeed(queryText: string): Promise<MentionItem[]> {
             seen.add(user.id);
             return true;
         })
-        .map((user: { name: string }) => ({ id: `@${user.name}`, label: user.name }));
+        .map((user: { name: string }) => ({
+            id: `@${user.name}`,
+            label: user.name,
+        }));
 }
 
 async function icdFeed(queryText: string): Promise<MentionItem[]> {
@@ -156,7 +164,15 @@ export default function ReferralNotesEditor({
                 onChange={(_event, editor) => onChange(editor.getData())}
                 config={{
                     licenseKey: 'GPL',
-                    plugins: [Essentials, Paragraph, Bold, Italic, Underline, List, Mention],
+                    plugins: [
+                        Essentials,
+                        Paragraph,
+                        Bold,
+                        Italic,
+                        Underline,
+                        List,
+                        Mention,
+                    ],
                     toolbar: [
                         'bold',
                         'italic',
@@ -169,10 +185,30 @@ export default function ReferralNotesEditor({
                     ],
                     mention: {
                         feeds: [
-                            { marker: '#', feed: drugFeed, itemRenderer: renderMentionItem, minimumCharacters: 1 },
-                            { marker: '@', feed: doctorFeed, itemRenderer: renderMentionItem, minimumCharacters: 1 },
-                            { marker: '&', feed: icdFeed, itemRenderer: renderMentionItem, minimumCharacters: 1 },
-                            { marker: '!', feed: closingFeed, itemRenderer: renderMentionItem, minimumCharacters: 1 },
+                            {
+                                marker: '#',
+                                feed: drugFeed,
+                                itemRenderer: renderMentionItem,
+                                minimumCharacters: 1,
+                            },
+                            {
+                                marker: '@',
+                                feed: doctorFeed,
+                                itemRenderer: renderMentionItem,
+                                minimumCharacters: 1,
+                            },
+                            {
+                                marker: '&',
+                                feed: icdFeed,
+                                itemRenderer: renderMentionItem,
+                                minimumCharacters: 1,
+                            },
+                            {
+                                marker: '!',
+                                feed: closingFeed,
+                                itemRenderer: renderMentionItem,
+                                minimumCharacters: 1,
+                            },
                         ],
                     },
                 }}

--- a/resources/views/pdfs/birth-certificate.blade.php
+++ b/resources/views/pdfs/birth-certificate.blade.php
@@ -1,0 +1,98 @@
+@php
+    $hospitalName = \App\Models\HospitalSetting::get('hospital_name', config('app.name'));
+    $hospitalAddress = \App\Models\HospitalSetting::get('hospital_address');
+    $hospitalPhone = \App\Models\HospitalSetting::get('hospital_phone');
+    $genderLabels = ['m' => 'Male', 'f' => 'Female', 't' => 'Transgender', 'o' => 'Other'];
+    $doctorName = $certificate->attendingDoctor?->name ?? '';
+    if ($certificate->attendingDoctor?->pmdc_number) {
+        $doctorName .= " (PMDC# {$certificate->attendingDoctor->pmdc_number})";
+    }
+    $verificationUrl = \App\Helpers\QrCodeHelper::verificationUrl('v/bc/'.$certificate->verification_token);
+    $qrDataUri = \App\Helpers\QrCodeHelper::dataUri($verificationUrl, 48);
+@endphp
+<div class="page" style="page-break-before: always; font-family: Arial, Helvetica, sans-serif; font-size: 11px; color: #111;">
+    <style>
+        .bc-table{ width:100%; border-collapse:collapse; }
+        .bc-table td, .bc-table th{ border:1px solid #222; padding:5px 7px; vertical-align:top; }
+        .bc-label{ font-weight:700; background:#f0f0f0; white-space:nowrap; }
+        .bc-title{ text-align:center; font-weight:800; font-size:15px; letter-spacing:.5px; margin: 4px 0 2px 0; text-decoration: underline; }
+        .bc-sub{ text-align:center; font-size:11px; margin-bottom:8px; }
+        .bc-head{ text-align:center; }
+        .bc-head .name{ font-weight:800; font-size:14px; }
+        .bc-sig-box{ border:1px solid #222; padding:10px; height:60px; margin-top:4px; }
+        .bc-stamp-box{ border:1px dashed #666; padding:10px; height:70px; text-align:center; color:#666; }
+        .bc-qr{ width:48px; height:48px; }
+        .bc-qr-caption{ font-size:7px; color:#666; text-align:center; width:60px; word-break:break-all; }
+    </style>
+
+    <table style="width:100%; border-collapse:collapse;">
+        <tr>
+            <td style="width:60px; border:0; text-align:center; vertical-align:top;">
+                <img src="{{ $qrDataUri }}" class="bc-qr" alt="Verify">
+                <div class="bc-qr-caption">Scan to verify</div>
+            </td>
+            <td class="bc-head" style="border:0;">
+                <div class="name">{{ strtoupper($hospitalName) }}</div>
+                @if($hospitalAddress)<div>{{ $hospitalAddress }}</div>@endif
+                @if($hospitalPhone)<div>{{ $hospitalPhone }}</div>@endif
+            </td>
+            <td style="width:60px; border:0;"></td>
+        </tr>
+    </table>
+
+    <div class="bc-title">BIRTH CERTIFICATE</div>
+    <div class="bc-sub">Certificate No: <strong>{{ $certificate->birth_certificate_number }}</strong> &nbsp;|&nbsp; Service Order: <strong>{{ $serviceOrder->so_number }}</strong></div>
+
+    <table class="bc-table">
+        <tr>
+            <td class="bc-label" style="width:22%;">Child's Name</td>
+            <td style="width:53%;">{{ $certificate->child_name ?: 'Baby of '.($certificate->mother_name ?? $patient->name ?? '') }}</td>
+            <td class="bc-label" style="width:10%;">Gender</td>
+            <td style="width:15%;">{{ $genderLabels[$certificate->gender] ?? $certificate->gender }}</td>
+        </tr>
+        <tr>
+            <td class="bc-label">Date of Birth</td>
+            <td>{{ $certificate->date_of_birth?->format('d-m-Y') }}</td>
+            <td class="bc-label">Time of Birth</td>
+            <td>{{ $certificate->time_of_birth ? \Illuminate\Support\Carbon::parse($certificate->time_of_birth)->format('H:i') : '' }}</td>
+        </tr>
+        <tr>
+            <td class="bc-label">Place of Birth</td>
+            <td>{{ $certificate->place_of_birth ?: $hospitalName }}</td>
+            <td class="bc-label">Weight at Birth</td>
+            <td>{{ $certificate->weight_at_birth ? $certificate->weight_at_birth.' kg' : '' }}</td>
+        </tr>
+        <tr>
+            <td class="bc-label">Mother's Name</td>
+            <td>{{ $certificate->mother_name }}</td>
+            <td class="bc-label">Mother's CNIC</td>
+            <td>{{ $certificate->mother_cnic }}</td>
+        </tr>
+        <tr>
+            <td class="bc-label">Father's Name</td>
+            <td>{{ $certificate->father_name }}</td>
+            <td class="bc-label">Father's CNIC</td>
+            <td>{{ $certificate->father_cnic }}</td>
+        </tr>
+        <tr>
+            <td class="bc-label">Remarks</td>
+            <td colspan="3">{{ $certificate->remarks }}</td>
+        </tr>
+    </table>
+
+    <table style="width:100%; margin-top:14px; border-collapse:collapse;">
+        <tr>
+            <td style="width:33%; vertical-align:top; padding-right:6px; border:0;">
+                <div class="bc-sig-box">{{ $doctorName }}</div>
+                <div style="text-align:center; font-weight:700; margin-top:2px;">Attending Doctor</div>
+            </td>
+            <td style="width:33%; vertical-align:top; padding-right:6px; border:0;">
+                <div class="bc-sig-box"></div>
+                <div style="text-align:center; font-weight:700; margin-top:2px;">Medical Superintendent</div>
+            </td>
+            <td style="width:34%; vertical-align:top; border:0;">
+                <div class="bc-stamp-box">Hospital Stamp</div>
+            </td>
+        </tr>
+    </table>
+</div>

--- a/resources/views/pdfs/death-certificate.blade.php
+++ b/resources/views/pdfs/death-certificate.blade.php
@@ -1,0 +1,115 @@
+@php
+    $hospitalName = \App\Models\HospitalSetting::get('hospital_name', config('app.name'));
+    $hospitalAddress = \App\Models\HospitalSetting::get('hospital_address');
+    $hospitalPhone = \App\Models\HospitalSetting::get('hospital_phone');
+    $tr = $serviceOrder->treatmentRecord;
+    $treatingDoctor = $tr?->treatingDoctor ?? $serviceOrder->doctor;
+    $treatingDoctorName = $treatingDoctor?->name ?? '';
+    if ($treatingDoctor?->pmdc_number) {
+        $treatingDoctorName .= " (PMDC# {$treatingDoctor->pmdc_number})";
+    }
+    $verificationUrl = \App\Helpers\QrCodeHelper::verificationUrl('v/dc/'.$certificate->verification_token);
+    $qrDataUri = \App\Helpers\QrCodeHelper::dataUri($verificationUrl, 48);
+@endphp
+<div class="page" style="page-break-before: always; font-family: Arial, Helvetica, sans-serif; font-size: 11px; color: #111;">
+    <style>
+        .dc-table{ width:100%; border-collapse:collapse; }
+        .dc-table td, .dc-table th{ border:1px solid #222; padding:5px 7px; vertical-align:top; }
+        .dc-label{ font-weight:700; background:#f0f0f0; white-space:nowrap; }
+        .dc-title{ text-align:center; font-weight:800; font-size:15px; letter-spacing:.5px; margin: 4px 0 2px 0; text-decoration: underline; }
+        .dc-sub{ text-align:center; font-size:11px; margin-bottom:8px; }
+        .dc-head{ text-align:center; }
+        .dc-head .name{ font-weight:800; font-size:14px; }
+        .dc-sig-box{ border:1px solid #222; padding:10px; height:60px; margin-top:4px; }
+        .dc-stamp-box{ border:1px dashed #666; padding:10px; height:70px; text-align:center; color:#666; }
+        .dc-qr{ width:48px; height:48px; }
+        .dc-qr-caption{ font-size:7px; color:#666; text-align:center; width:60px; word-break:break-all; }
+    </style>
+
+    <table style="width:100%; border-collapse:collapse;">
+        <tr>
+            <td style="width:60px; border:0; text-align:center; vertical-align:top;">
+                <img src="{{ $qrDataUri }}" class="dc-qr" alt="Verify">
+                <div class="dc-qr-caption">Scan to verify</div>
+            </td>
+            <td class="dc-head" style="border:0;">
+                <div class="name">{{ strtoupper($hospitalName) }}</div>
+                @if($hospitalAddress)<div>{{ $hospitalAddress }}</div>@endif
+                @if($hospitalPhone)<div>{{ $hospitalPhone }}</div>@endif
+            </td>
+            <td style="width:60px; border:0;"></td>
+        </tr>
+    </table>
+
+    <div class="dc-title">MEDICAL CERTIFICATE OF CAUSE OF DEATH</div>
+    <div class="dc-sub">Certificate No: <strong>{{ $certificate->certificate_number }}</strong> &nbsp;|&nbsp; Service Order: <strong>{{ $serviceOrder->so_number }}</strong></div>
+
+    <table class="dc-table">
+        <tr>
+            <td class="dc-label" style="width:22%;">Patient Name</td>
+            <td style="width:53%;">{{ $patient->name ?? '' }}</td>
+            <td class="dc-label" style="width:10%;">Age / Sex</td>
+            <td style="width:15%;">{{ $patient->age ?? '' }} / {{ $patient->gender ?? '' }}</td>
+        </tr>
+        <tr>
+            <td class="dc-label">S/o, D/o, W/o</td>
+            <td colspan="3">{{ trim(($patient->relation ?? '').' '.($patient->guardian ?? '')) }}</td>
+        </tr>
+        <tr>
+            <td class="dc-label">Address</td>
+            <td colspan="3">{{ $patient->address ?? '' }}</td>
+        </tr>
+        <tr>
+            <td class="dc-label">Date of Death</td>
+            <td>{{ $certificate->date_of_death?->format('d-m-Y') }}</td>
+            <td class="dc-label">Time of Death</td>
+            <td>{{ $certificate->time_of_death ? \Illuminate\Support\Carbon::parse($certificate->time_of_death)->format('H:i') : '' }}</td>
+        </tr>
+        <tr>
+            <td class="dc-label">Place of Death</td>
+            <td colspan="3">{{ $certificate->place_of_death }}</td>
+        </tr>
+        <tr>
+            <td class="dc-label">Immediate Cause of Death</td>
+            <td colspan="3">{{ trim(($tr?->diagnosis_code ?? '').' '.($tr?->diagnosis_text ?? '')) }}</td>
+        </tr>
+        <tr>
+            <td class="dc-label">Antecedent Cause</td>
+            <td colspan="3">{{ $certificate->antecedent_cause }}</td>
+        </tr>
+        <tr>
+            <td class="dc-label">Manner of Death</td>
+            <td colspan="3">{{ $certificate->manner_of_death?->label() }}</td>
+        </tr>
+        <tr>
+            <td class="dc-label">Informant Name</td>
+            <td>{{ $certificate->informant_name }}</td>
+            <td class="dc-label">Relation</td>
+            <td>{{ $certificate->informant_relation }}</td>
+        </tr>
+        <tr>
+            <td class="dc-label">Informant CNIC</td>
+            <td colspan="3">{{ $certificate->informant_cnic }}</td>
+        </tr>
+        <tr>
+            <td class="dc-label">Remarks</td>
+            <td colspan="3">{{ $certificate->remarks }}</td>
+        </tr>
+    </table>
+
+    <table style="width:100%; margin-top:14px; border-collapse:collapse;">
+        <tr>
+            <td style="width:33%; vertical-align:top; padding-right:6px; border:0;">
+                <div class="dc-sig-box">{{ $treatingDoctorName }}</div>
+                <div style="text-align:center; font-weight:700; margin-top:2px;">Certifying Doctor</div>
+            </td>
+            <td style="width:33%; vertical-align:top; padding-right:6px; border:0;">
+                <div class="dc-sig-box"></div>
+                <div style="text-align:center; font-weight:700; margin-top:2px;">Medical Superintendent</div>
+            </td>
+            <td style="width:34%; vertical-align:top; border:0;">
+                <div class="dc-stamp-box">Hospital Stamp</div>
+            </td>
+        </tr>
+    </table>
+</div>

--- a/resources/views/pdfs/referral-certificate.blade.php
+++ b/resources/views/pdfs/referral-certificate.blade.php
@@ -1,0 +1,81 @@
+@php
+    $hospitalName = \App\Models\HospitalSetting::get('hospital_name', config('app.name'));
+    $hospitalAddress = \App\Models\HospitalSetting::get('hospital_address');
+    $hospitalPhone = \App\Models\HospitalSetting::get('hospital_phone');
+    $tr = $serviceOrder->treatmentRecord;
+    $referringDoctor = $tr?->treatingDoctor ?? $serviceOrder->doctor;
+    $referringDoctorName = $referringDoctor?->name ?? '';
+    if ($referringDoctor?->pmdc_number) {
+        $referringDoctorName .= " (PMDC# {$referringDoctor->pmdc_number})";
+    }
+@endphp
+<div class="page" style="page-break-before: always; font-family: Arial, Helvetica, sans-serif; font-size: 11px; color: #111;">
+    <style>
+        .rc-table{ width:100%; border-collapse:collapse; }
+        .rc-table td, .rc-table th{ border:1px solid #222; padding:5px 7px; vertical-align:top; }
+        .rc-label{ font-weight:700; background:#f0f0f0; white-space:nowrap; }
+        .rc-title{ text-align:center; font-weight:800; font-size:15px; letter-spacing:.5px; margin: 4px 0 2px 0; text-decoration: underline; }
+        .rc-sub{ text-align:center; font-size:11px; margin-bottom:8px; }
+        .rc-head{ text-align:center; }
+        .rc-head .name{ font-weight:800; font-size:14px; }
+        .rc-notes{ border:1px solid #222; padding:8px; min-height:160px; margin-top:8px; }
+        .rc-sig-box{ border:1px solid #222; padding:10px; height:60px; margin-top:4px; }
+        .rc-stamp-box{ border:1px dashed #666; padding:10px; height:70px; text-align:center; color:#666; }
+    </style>
+
+    <div class="rc-head">
+        <div class="name">{{ strtoupper($hospitalName) }}</div>
+        @if($hospitalAddress)<div>{{ $hospitalAddress }}</div>@endif
+        @if($hospitalPhone)<div>{{ $hospitalPhone }}</div>@endif
+    </div>
+
+    <div class="rc-title">REFERRAL CERTIFICATE</div>
+    <div class="rc-sub">Referral No: <strong>{{ $referral->referral_number }}</strong> &nbsp;|&nbsp; Service Order: <strong>{{ $serviceOrder->so_number }}</strong></div>
+
+    <table class="rc-table">
+        <tr>
+            <td class="rc-label" style="width:22%;">Patient Name</td>
+            <td style="width:53%;">{{ $patient->name ?? '' }}</td>
+            <td class="rc-label" style="width:10%;">Age / Sex</td>
+            <td style="width:15%;">{{ $patient->age ?? '' }} / {{ $patient->gender ?? '' }}</td>
+        </tr>
+        <tr>
+            <td class="rc-label">Address</td>
+            <td colspan="3">{{ $patient->address ?? '' }}</td>
+        </tr>
+        <tr>
+            <td class="rc-label">Referring Facility</td>
+            <td>{{ $hospitalName }}</td>
+            <td class="rc-label">Referring Doctor</td>
+            <td>{{ $referringDoctorName }}</td>
+        </tr>
+        <tr>
+            <td class="rc-label">Receiving Facility</td>
+            <td colspan="3">{{ $referral->receiving_facility_name }}</td>
+        </tr>
+        <tr>
+            <td class="rc-label">Diagnosis</td>
+            <td colspan="3">{{ trim(($tr?->diagnosis_code ?? '').' '.($tr?->diagnosis_text ?? '')) }}</td>
+        </tr>
+    </table>
+
+    <div class="rc-notes">
+        {!! $referral->notes !!}
+    </div>
+
+    <table style="width:100%; margin-top:14px; border-collapse:collapse;">
+        <tr>
+            <td style="width:33%; vertical-align:top; padding-right:6px; border:0;">
+                <div class="rc-sig-box">{{ $referringDoctorName }}</div>
+                <div style="text-align:center; font-weight:700; margin-top:2px;">Referring Doctor</div>
+            </td>
+            <td style="width:33%; vertical-align:top; padding-right:6px; border:0;">
+                <div class="rc-sig-box"></div>
+                <div style="text-align:center; font-weight:700; margin-top:2px;">Receiving Doctor</div>
+            </td>
+            <td style="width:34%; vertical-align:top; border:0;">
+                <div class="rc-stamp-box">Hospital Stamp</div>
+            </td>
+        </tr>
+    </table>
+</div>

--- a/resources/views/public/birth-certificate.blade.php
+++ b/resources/views/public/birth-certificate.blade.php
@@ -1,0 +1,78 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex, nofollow">
+    <title>Birth Certificate Verification</title>
+    <style>
+        * { box-sizing: border-box; }
+        body {
+            margin: 0;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif;
+            background: #f1f5f9;
+            color: #0f172a;
+            padding: 24px 16px;
+        }
+        .card {
+            max-width: 480px;
+            margin: 0 auto;
+            background: #fff;
+            border-radius: 16px;
+            box-shadow: 0 1px 3px rgba(0,0,0,.08);
+            overflow: hidden;
+        }
+        .header {
+            background: #0f172a;
+            color: #fff;
+            padding: 20px;
+            text-align: center;
+        }
+        .header .hospital { font-weight: 700; font-size: 16px; }
+        .badge {
+            display: inline-block;
+            margin-top: 8px;
+            padding: 4px 12px;
+            background: #16a34a;
+            border-radius: 999px;
+            font-size: 12px;
+            font-weight: 600;
+            letter-spacing: .3px;
+        }
+        .body { padding: 20px; }
+        .title { font-size: 18px; font-weight: 700; margin: 0 0 4px 0; }
+        .subtitle { color: #64748b; font-size: 13px; margin: 0 0 16px 0; }
+        dl { margin: 0; }
+        .row { display: flex; justify-content: space-between; gap: 12px; padding: 8px 0; border-bottom: 1px solid #f1f5f9; }
+        .row:last-child { border-bottom: 0; }
+        dt { color: #64748b; font-size: 13px; }
+        dd { margin: 0; font-weight: 600; font-size: 13px; text-align: right; }
+        .footer { padding: 14px 20px; background: #f8fafc; font-size: 11px; color: #94a3b8; text-align: center; }
+    </style>
+</head>
+<body>
+    @php $genderLabels = ['m' => 'Male', 'f' => 'Female', 't' => 'Transgender', 'o' => 'Other']; @endphp
+    <div class="card">
+        <div class="header">
+            <div class="hospital">{{ strtoupper(\App\Models\HospitalSetting::get('hospital_name', config('app.name'))) }}</div>
+            <span class="badge">✓ Verified Official Record</span>
+        </div>
+        <div class="body">
+            <p class="title">Birth Certificate</p>
+            <p class="subtitle">Certificate No: {{ $certificate->birth_certificate_number }}</p>
+
+            <dl>
+                <div class="row"><dt>Child's Name</dt><dd>{{ $certificate->child_name ?: 'Baby of '.($certificate->mother_name ?? '') }}</dd></div>
+                <div class="row"><dt>Gender</dt><dd>{{ $genderLabels[$certificate->gender] ?? $certificate->gender }}</dd></div>
+                <div class="row"><dt>Date of Birth</dt><dd>{{ $certificate->date_of_birth?->format('d-m-Y') }}</dd></div>
+                <div class="row"><dt>Time of Birth</dt><dd>{{ $certificate->time_of_birth ? \Illuminate\Support\Carbon::parse($certificate->time_of_birth)->format('H:i') : '' }}</dd></div>
+                <div class="row"><dt>Mother's Name</dt><dd>{{ $certificate->mother_name }}</dd></div>
+                <div class="row"><dt>Service Order</dt><dd>{{ $certificate->serviceOrder->so_number }}</dd></div>
+            </dl>
+        </div>
+        <div class="footer">
+            This page confirms the authenticity of an official record issued by {{ \App\Models\HospitalSetting::get('hospital_name', config('app.name')) }}.
+        </div>
+    </div>
+</body>
+</html>

--- a/resources/views/public/death-certificate.blade.php
+++ b/resources/views/public/death-certificate.blade.php
@@ -1,0 +1,79 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex, nofollow">
+    <title>Death Certificate Verification</title>
+    <style>
+        * { box-sizing: border-box; }
+        body {
+            margin: 0;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif;
+            background: #f1f5f9;
+            color: #0f172a;
+            padding: 24px 16px;
+        }
+        .card {
+            max-width: 480px;
+            margin: 0 auto;
+            background: #fff;
+            border-radius: 16px;
+            box-shadow: 0 1px 3px rgba(0,0,0,.08);
+            overflow: hidden;
+        }
+        .header {
+            background: #0f172a;
+            color: #fff;
+            padding: 20px;
+            text-align: center;
+        }
+        .header .hospital { font-weight: 700; font-size: 16px; }
+        .badge {
+            display: inline-block;
+            margin-top: 8px;
+            padding: 4px 12px;
+            background: #16a34a;
+            border-radius: 999px;
+            font-size: 12px;
+            font-weight: 600;
+            letter-spacing: .3px;
+        }
+        .body { padding: 20px; }
+        .title { font-size: 18px; font-weight: 700; margin: 0 0 4px 0; }
+        .subtitle { color: #64748b; font-size: 13px; margin: 0 0 16px 0; }
+        dl { margin: 0; }
+        .row { display: flex; justify-content: space-between; gap: 12px; padding: 8px 0; border-bottom: 1px solid #f1f5f9; }
+        .row:last-child { border-bottom: 0; }
+        dt { color: #64748b; font-size: 13px; }
+        dd { margin: 0; font-weight: 600; font-size: 13px; text-align: right; }
+        .footer { padding: 14px 20px; background: #f8fafc; font-size: 11px; color: #94a3b8; text-align: center; }
+    </style>
+</head>
+<body>
+    <div class="card">
+        <div class="header">
+            <div class="hospital">{{ strtoupper(\App\Models\HospitalSetting::get('hospital_name', config('app.name'))) }}</div>
+            <span class="badge">✓ Verified Official Record</span>
+        </div>
+        <div class="body">
+            <p class="title">Death Certificate</p>
+            <p class="subtitle">Certificate No: {{ $certificate->certificate_number }}</p>
+
+            <dl>
+                <div class="row"><dt>Patient Name</dt><dd>{{ $patient->name ?? '' }}</dd></div>
+                <div class="row"><dt>Date of Death</dt><dd>{{ $certificate->date_of_death?->format('d-m-Y') }}</dd></div>
+                <div class="row"><dt>Time of Death</dt><dd>{{ $certificate->time_of_death ? \Illuminate\Support\Carbon::parse($certificate->time_of_death)->format('H:i') : '' }}</dd></div>
+                <div class="row"><dt>Place of Death</dt><dd>{{ $certificate->place_of_death }}</dd></div>
+                @if($certificate->manner_of_death)
+                    <div class="row"><dt>Manner of Death</dt><dd>{{ $certificate->manner_of_death->label() }}</dd></div>
+                @endif
+                <div class="row"><dt>Service Order</dt><dd>{{ $certificate->serviceOrder->so_number }}</dd></div>
+            </dl>
+        </div>
+        <div class="footer">
+            This page confirms the authenticity of an official record issued by {{ \App\Models\HospitalSetting::get('hospital_name', config('app.name')) }}.
+        </div>
+    </div>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\OpdDoctorController;
 use App\Http\Controllers\Prints\ClosingStatementPdfPrintController;
 use App\Http\Controllers\Prints\ServiceOrderPdfPrintController;
 use App\Http\Controllers\Prints\TransactionPdfPrintController;
+use App\Http\Controllers\PublicCertificateController;
 use App\Http\Controllers\Reports\BankPaymentReportController;
 use App\Http\Controllers\Reports\GenericReportPdfController;
 use App\Http\Controllers\Reports\IncomeCashFlowReportController;
@@ -211,5 +212,13 @@ Route::middleware(['auth', 'verified'])->group(function () {
 /**
  * Print routes (no auth required for printing)
  */
+
+// Public QR-code verification pages for Death/Birth certificates — gated by
+// an unguessable token, not authentication. Short path on purpose: keeps the
+// printed QR code small and easy to scan.
+Route::get('v/dc/{token}', [PublicCertificateController::class, 'deathCertificate'])
+    ->name('public-death-certificate');
+Route::get('v/bc/{token}', [PublicCertificateController::class, 'birthCertificate'])
+    ->name('public-birth-certificate');
 
 require __DIR__.'/settings.php';

--- a/tests/Feature/Api/DepartmentControllerDischargeTest.php
+++ b/tests/Feature/Api/DepartmentControllerDischargeTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\EmergencyDoctor;
 use App\Models\NursingStaff;
+use App\Models\ReferralCertificate;
 use App\Models\ServiceOrder;
 use App\Models\Triage;
 use App\Models\User;
@@ -64,6 +65,56 @@ test('a doctor can discharge an EMG patient with a full disposition', function (
     expect($treatmentRecord->outcome->value)->toBe('discharged');
     expect($treatmentRecord->outcome_notes)->toBe('Stable, advised rest');
     expect($treatmentRecord->is_finalized)->toBeTrue();
+});
+
+test('referral_notes are written to the auto-created referral certificate on finalize', function () {
+    $doctor = User::factory()->create();
+    EmergencyDoctor::factory()->create(['user_id' => $doctor->id]);
+    $this->actingAs($doctor);
+
+    $serviceOrder = ServiceOrder::factory()->create(['type' => 'EMG']);
+    $triage = Triage::factory()->create();
+
+    $response = $this->postJson("/api/emg/service-orders/{$serviceOrder->id}/treatment-record", [
+        'triage_id' => $triage->id,
+        'treated_at' => now()->toIso8601String(),
+        'outcome' => 'referred',
+        'outcome_at' => now()->toIso8601String(),
+        'referral_to' => 'City General Hospital',
+        'referral_notes' => '<p>Stable for transfer. #Aspirin given.</p>',
+        'finalize' => true,
+    ]);
+
+    $response->assertOk();
+
+    $certificate = ReferralCertificate::where('service_order_id', $serviceOrder->id)->first();
+    expect($certificate)->not->toBeNull()
+        ->and($certificate->receiving_facility_name)->toBe('City General Hospital')
+        ->and($certificate->notes)->toContain('Stable for transfer')
+        ->and($certificate->notes)->toContain('#Aspirin given');
+});
+
+test('referral_notes are sanitized before being stored on the referral certificate', function () {
+    $doctor = User::factory()->create();
+    EmergencyDoctor::factory()->create(['user_id' => $doctor->id]);
+    $this->actingAs($doctor);
+
+    $serviceOrder = ServiceOrder::factory()->create(['type' => 'EMG']);
+    $triage = Triage::factory()->create();
+
+    $this->postJson("/api/emg/service-orders/{$serviceOrder->id}/treatment-record", [
+        'triage_id' => $triage->id,
+        'treated_at' => now()->toIso8601String(),
+        'outcome' => 'referred',
+        'outcome_at' => now()->toIso8601String(),
+        'referral_to' => 'City General Hospital',
+        'referral_notes' => '<p onclick="alert(1)">Notes</p><script>alert(2)</script>',
+        'finalize' => true,
+    ])->assertOk();
+
+    $certificate = ReferralCertificate::where('service_order_id', $serviceOrder->id)->first();
+    expect($certificate->notes)->not->toContain('<script>')
+        ->and($certificate->notes)->not->toContain('onclick');
 });
 
 test('a nursing-staff-only user cannot discharge (finalize) an EMG patient', function () {

--- a/tests/Feature/Filament/Admin/BirthCertificateResourceTest.php
+++ b/tests/Feature/Filament/Admin/BirthCertificateResourceTest.php
@@ -1,0 +1,84 @@
+<?php
+
+use App\Filament\Admin\Resources\BirthCertificates\Pages\CreateBirthCertificate;
+use App\Filament\Admin\Resources\BirthCertificates\Pages\EditBirthCertificate;
+use App\Filament\Admin\Resources\BirthCertificates\Pages\ListBirthCertificates;
+use App\Models\Administrator;
+use App\Models\BirthCertificate;
+use App\Models\ServiceOrder;
+use App\Models\User;
+
+use function Pest\Laravel\assertDatabaseHas;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    Administrator::create(['user_id' => $this->user->id, 'authority' => 'administrator']);
+    $this->actingAs($this->user);
+});
+
+test('birth certificate list page renders and shows records', function () {
+    $certificates = BirthCertificate::factory()->count(2)->create();
+
+    Livewire\Livewire::test(ListBirthCertificates::class)
+        ->assertSuccessful()
+        ->assertCanSeeTableRecords($certificates);
+});
+
+test('admin can create a birth certificate for a service order', function () {
+    $serviceOrder = ServiceOrder::factory()->create();
+
+    Livewire\Livewire::test(CreateBirthCertificate::class)
+        ->fillForm([
+            'service_order_id' => $serviceOrder->id,
+            'child_name' => 'Baby Ahmed',
+            'gender' => 'm',
+            'mother_name' => 'Sadia Ahmed',
+        ])
+        ->call('create')
+        ->assertNotified()
+        ->assertRedirect();
+
+    assertDatabaseHas(BirthCertificate::class, [
+        'service_order_id' => $serviceOrder->id,
+        'child_name' => 'Baby Ahmed',
+        'is_locked' => false,
+    ]);
+});
+
+test('admin can update an unlocked birth certificate', function () {
+    $certificate = BirthCertificate::factory()->create();
+
+    Livewire\Livewire::test(EditBirthCertificate::class, ['record' => $certificate->getRouteKey()])
+        ->fillForm(['child_name' => 'Updated Name'])
+        ->call('save')
+        ->assertNotified();
+
+    assertDatabaseHas(BirthCertificate::class, [
+        'id' => $certificate->id,
+        'child_name' => 'Updated Name',
+    ]);
+});
+
+test('the lock action is visible for an unlocked certificate and hidden for a locked one', function () {
+    $unlocked = BirthCertificate::factory()->create();
+    $locked = BirthCertificate::factory()->locked()->create();
+
+    Livewire\Livewire::test(EditBirthCertificate::class, ['record' => $unlocked->getRouteKey()])
+        ->assertActionVisible('lock');
+
+    Livewire\Livewire::test(EditBirthCertificate::class, ['record' => $locked->getRouteKey()])
+        ->assertActionHidden('lock');
+});
+
+test('admin can lock a birth certificate via the lock action', function () {
+    $certificate = BirthCertificate::factory()->create();
+
+    Livewire\Livewire::test(EditBirthCertificate::class, ['record' => $certificate->getRouteKey()])
+        ->callAction('lock')
+        ->assertNotified();
+
+    $certificate->refresh();
+    expect($certificate->is_locked)->toBeTrue()
+        ->and($certificate->locked_at)->not->toBeNull()
+        ->and($certificate->locked_by)->toBe($this->user->id);
+});

--- a/tests/Feature/Filament/Admin/DeathCertificateResourceTest.php
+++ b/tests/Feature/Filament/Admin/DeathCertificateResourceTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use App\Enum\DeathCertificateManner;
+use App\Filament\Admin\Resources\DeathCertificates\Pages\CreateDeathCertificate;
+use App\Filament\Admin\Resources\DeathCertificates\Pages\EditDeathCertificate;
+use App\Filament\Admin\Resources\DeathCertificates\Pages\ListDeathCertificates;
+use App\Models\Administrator;
+use App\Models\DeathCertificate;
+use App\Models\ServiceOrder;
+use App\Models\User;
+
+use function Pest\Laravel\assertDatabaseHas;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    Administrator::create(['user_id' => $this->user->id, 'authority' => 'administrator']);
+    $this->actingAs($this->user);
+});
+
+test('death certificate list page renders and shows records', function () {
+    $certificates = DeathCertificate::factory()->count(2)->create();
+
+    Livewire\Livewire::test(ListDeathCertificates::class)
+        ->assertSuccessful()
+        ->assertCanSeeTableRecords($certificates);
+});
+
+test('admin can create a death certificate for a service order', function () {
+    $serviceOrder = ServiceOrder::factory()->create();
+
+    Livewire\Livewire::test(CreateDeathCertificate::class)
+        ->fillForm([
+            'service_order_id' => $serviceOrder->id,
+            'place_of_death' => 'Emergency Ward',
+            'manner_of_death' => DeathCertificateManner::Natural->value,
+            'informant_name' => 'Muhammad Ali',
+        ])
+        ->call('create')
+        ->assertNotified()
+        ->assertRedirect();
+
+    assertDatabaseHas(DeathCertificate::class, [
+        'service_order_id' => $serviceOrder->id,
+        'place_of_death' => 'Emergency Ward',
+        'manner_of_death' => DeathCertificateManner::Natural->value,
+    ]);
+});
+
+test('admin can update a death certificate', function () {
+    $certificate = DeathCertificate::factory()->create();
+
+    Livewire\Livewire::test(EditDeathCertificate::class, ['record' => $certificate->getRouteKey()])
+        ->fillForm(['antecedent_cause' => 'Chronic renal failure'])
+        ->call('save')
+        ->assertNotified();
+
+    assertDatabaseHas(DeathCertificate::class, [
+        'id' => $certificate->id,
+        'antecedent_cause' => 'Chronic renal failure',
+    ]);
+});

--- a/tests/Feature/Filament/Admin/ReferralCertificateResourceTest.php
+++ b/tests/Feature/Filament/Admin/ReferralCertificateResourceTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use App\Filament\Admin\Resources\ReferralCertificates\Pages\CreateReferralCertificate;
+use App\Filament\Admin\Resources\ReferralCertificates\Pages\EditReferralCertificate;
+use App\Filament\Admin\Resources\ReferralCertificates\Pages\ListReferralCertificates;
+use App\Models\Administrator;
+use App\Models\ReferralCertificate;
+use App\Models\ServiceOrder;
+use App\Models\User;
+
+use function Pest\Laravel\assertDatabaseHas;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    Administrator::create(['user_id' => $this->user->id, 'authority' => 'administrator']);
+    $this->actingAs($this->user);
+});
+
+test('referral certificate list page renders and shows records', function () {
+    $certificates = ReferralCertificate::factory()->count(2)->create();
+
+    Livewire\Livewire::test(ListReferralCertificates::class)
+        ->assertSuccessful()
+        ->assertCanSeeTableRecords($certificates);
+});
+
+test('admin can create a referral certificate for a service order', function () {
+    $serviceOrder = ServiceOrder::factory()->create();
+
+    Livewire\Livewire::test(CreateReferralCertificate::class)
+        ->fillForm([
+            'service_order_id' => $serviceOrder->id,
+            'receiving_facility_name' => 'City General Hospital',
+        ])
+        ->call('create')
+        ->assertNotified()
+        ->assertRedirect();
+
+    assertDatabaseHas(ReferralCertificate::class, [
+        'service_order_id' => $serviceOrder->id,
+        'receiving_facility_name' => 'City General Hospital',
+    ]);
+});
+
+test('admin can update a referral certificate', function () {
+    $certificate = ReferralCertificate::factory()->create();
+
+    Livewire\Livewire::test(EditReferralCertificate::class, ['record' => $certificate->getRouteKey()])
+        ->fillForm(['receiving_facility_name' => 'Updated Hospital'])
+        ->call('save')
+        ->assertNotified();
+
+    assertDatabaseHas(ReferralCertificate::class, [
+        'id' => $certificate->id,
+        'receiving_facility_name' => 'Updated Hospital',
+    ]);
+});

--- a/tests/Feature/Helpers/QrCodeHelperTest.php
+++ b/tests/Feature/Helpers/QrCodeHelperTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use App\Helpers\QrCodeHelper;
+use App\Models\HospitalSetting;
+
+test('verificationUrl uses the configured certificate_verification_domain when set', function () {
+    HospitalSetting::set('certificate_verification_domain', 'https://verify.example.com');
+
+    expect(QrCodeHelper::verificationUrl('v/dc/abc123'))
+        ->toBe('https://verify.example.com/v/dc/abc123');
+});
+
+test('verificationUrl strips a trailing slash from the configured domain', function () {
+    HospitalSetting::set('certificate_verification_domain', 'https://verify.example.com/');
+
+    expect(QrCodeHelper::verificationUrl('v/dc/abc123'))
+        ->toBe('https://verify.example.com/v/dc/abc123');
+});
+
+test('verificationUrl falls back to the app URL when no domain is configured', function () {
+    expect(QrCodeHelper::verificationUrl('v/dc/abc123'))
+        ->toBe(rtrim(config('app.url'), '/').'/v/dc/abc123');
+});
+
+test('verificationUrl falls back to the app URL when the configured domain is an empty string', function () {
+    HospitalSetting::set('certificate_verification_domain', '');
+
+    expect(QrCodeHelper::verificationUrl('v/dc/abc123'))
+        ->toBe(rtrim(config('app.url'), '/').'/v/dc/abc123');
+});
+
+test('dataUri produces an embeddable base64 PNG image', function () {
+    $dataUri = QrCodeHelper::dataUri('https://example.com/v/dc/abc123', 48);
+
+    expect($dataUri)->toStartWith('data:image/png;base64,');
+});

--- a/tests/Feature/Models/BirthCertificateModelTest.php
+++ b/tests/Feature/Models/BirthCertificateModelTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use App\Models\BirthCertificate;
+use Illuminate\Validation\ValidationException;
+
+test('birth certificate number is auto-generated in BC/YYYY/MM/NNNN format when not provided', function () {
+    $certificate = BirthCertificate::factory()->create(['birth_certificate_number' => null]);
+
+    expect($certificate->birth_certificate_number)->toMatch('/^BC\/\d{4}\/\d{2}\/\d{4}$/');
+});
+
+test('birth certificate numbers increment sequentially within the same month', function () {
+    $first = BirthCertificate::factory()->create(['birth_certificate_number' => null]);
+    $second = BirthCertificate::factory()->create(['birth_certificate_number' => null]);
+
+    $firstSeq = (int) explode('/', $first->birth_certificate_number)[3];
+    $secondSeq = (int) explode('/', $second->birth_certificate_number)[3];
+
+    expect($secondSeq)->toBe($firstSeq + 1);
+});
+
+test('a birth certificate is not locked by default', function () {
+    $certificate = BirthCertificate::factory()->create();
+
+    expect($certificate->is_locked)->toBeFalse();
+});
+
+test('an unlocked birth certificate can be edited', function () {
+    $certificate = BirthCertificate::factory()->create();
+
+    $certificate->update(['child_name' => 'Updated Name']);
+
+    expect($certificate->fresh()->child_name)->toBe('Updated Name');
+});
+
+test('a locked birth certificate cannot be edited', function () {
+    $certificate = BirthCertificate::factory()->locked()->create();
+
+    expect(fn () => $certificate->update(['child_name' => 'Changed Name']))
+        ->toThrow(ValidationException::class);
+});
+
+test('locking a birth certificate itself is allowed (the transition into locked)', function () {
+    $certificate = BirthCertificate::factory()->create(['is_locked' => false]);
+
+    $certificate->update(['is_locked' => true, 'locked_at' => now()]);
+
+    expect($certificate->fresh()->is_locked)->toBeTrue();
+});
+
+test('birth certificate cannot be hard deleted', function () {
+    $certificate = BirthCertificate::factory()->create();
+
+    expect(fn () => $certificate->forceDelete())->toThrow(RuntimeException::class);
+});
+
+test('birth certificate gets a verification token auto-assigned on create', function () {
+    $certificate = BirthCertificate::factory()->create();
+
+    expect($certificate->verification_token)->not->toBeNull()
+        ->and(strlen($certificate->verification_token))->toBe(40);
+});

--- a/tests/Feature/Models/DeathCertificateModelTest.php
+++ b/tests/Feature/Models/DeathCertificateModelTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use App\Enum\DeathCertificateManner;
+use App\Models\DeathCertificate;
+
+test('death certificate number is auto-generated in DC/YYYY/MM/NNNN format when not provided', function () {
+    $certificate = DeathCertificate::factory()->create(['certificate_number' => null]);
+
+    expect($certificate->certificate_number)->toMatch('/^DC\/\d{4}\/\d{2}\/\d{4}$/');
+});
+
+test('death certificate numbers increment sequentially within the same month', function () {
+    $first = DeathCertificate::factory()->create(['certificate_number' => null]);
+    $second = DeathCertificate::factory()->create(['certificate_number' => null]);
+
+    $firstSeq = (int) explode('/', $first->certificate_number)[3];
+    $secondSeq = (int) explode('/', $second->certificate_number)[3];
+
+    expect($secondSeq)->toBe($firstSeq + 1);
+});
+
+test('death certificate casts manner_of_death to the enum', function () {
+    $certificate = DeathCertificate::factory()->create([
+        'manner_of_death' => DeathCertificateManner::Natural,
+    ]);
+
+    expect($certificate->fresh()->manner_of_death)->toBe(DeathCertificateManner::Natural);
+});
+
+test('death certificate cannot be hard deleted', function () {
+    $certificate = DeathCertificate::factory()->create();
+
+    expect(fn () => $certificate->forceDelete())->toThrow(RuntimeException::class);
+});
+
+test('death certificate soft deletes normally', function () {
+    $certificate = DeathCertificate::factory()->create();
+
+    $certificate->delete();
+
+    expect($certificate->trashed())->toBeTrue()
+        ->and(DeathCertificate::withTrashed()->find($certificate->id))->not->toBeNull();
+});
+
+test('death certificate gets a verification token auto-assigned on create', function () {
+    $certificate = DeathCertificate::factory()->create();
+
+    expect($certificate->verification_token)->not->toBeNull()
+        ->and(strlen($certificate->verification_token))->toBe(40);
+});
+
+test('death certificate verification tokens are unique', function () {
+    $first = DeathCertificate::factory()->create();
+    $second = DeathCertificate::factory()->create();
+
+    expect($first->verification_token)->not->toBe($second->verification_token);
+});

--- a/tests/Feature/Models/ReferralCertificateModelTest.php
+++ b/tests/Feature/Models/ReferralCertificateModelTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use App\Models\ReferralCertificate;
+
+test('referral certificate number is auto-generated in RF/YYYY/MM/NNNN format when not provided', function () {
+    $certificate = ReferralCertificate::factory()->create(['referral_number' => null]);
+
+    expect($certificate->referral_number)->toMatch('/^RF\/\d{4}\/\d{2}\/\d{4}$/');
+});
+
+test('referral certificate numbers increment sequentially within the same month', function () {
+    $first = ReferralCertificate::factory()->create(['referral_number' => null]);
+    $second = ReferralCertificate::factory()->create(['referral_number' => null]);
+
+    $firstSeq = (int) explode('/', $first->referral_number)[3];
+    $secondSeq = (int) explode('/', $second->referral_number)[3];
+
+    expect($secondSeq)->toBe($firstSeq + 1);
+});
+
+test('referral certificate cannot be hard deleted', function () {
+    $certificate = ReferralCertificate::factory()->create();
+
+    expect(fn () => $certificate->forceDelete())->toThrow(RuntimeException::class);
+});
+
+test('sanitizeNotes strips script tags and event-handler attributes but keeps basic formatting', function () {
+    $dirty = '<p onclick="alert(1)">Hello <strong>world</strong></p><script>alert(2)</script><a href="javascript:alert(3)">link</a>';
+
+    $clean = ReferralCertificate::sanitizeNotes($dirty);
+
+    expect($clean)->toContain('<strong>world</strong>')
+        ->not->toContain('<script>')
+        ->not->toContain('onclick')
+        ->not->toContain('javascript:');
+});
+
+test('sanitizeNotes returns null for empty input', function () {
+    expect(ReferralCertificate::sanitizeNotes(null))->toBeNull()
+        ->and(ReferralCertificate::sanitizeNotes('   '))->toBeNull();
+});

--- a/tests/Feature/Observers/TreatmentRecordObserverTest.php
+++ b/tests/Feature/Observers/TreatmentRecordObserverTest.php
@@ -1,0 +1,159 @@
+<?php
+
+use App\Models\DeathCertificate;
+use App\Models\Patient;
+use App\Models\ReferralCertificate;
+use App\Models\ServiceDepartment;
+use App\Models\ServiceOrder;
+use App\Models\TreatmentRecord;
+use App\Models\User;
+
+test('a death certificate is auto-created when outcome is set to expired on create', function () {
+    $serviceOrder = ServiceOrder::factory()->create();
+
+    TreatmentRecord::create([
+        'service_order_id' => $serviceOrder->id,
+        'department_id' => $serviceOrder->service->service_department_id,
+        'treating_doctor_id' => User::factory()->create()->id,
+        'recorded_by' => User::factory()->create()->id,
+        'treated_at' => now(),
+        'outcome' => 'expired',
+        'outcome_at' => now(),
+    ]);
+
+    expect(DeathCertificate::where('service_order_id', $serviceOrder->id)->count())->toBe(1);
+});
+
+test('a death certificate is auto-created when outcome transitions to expired on update', function () {
+    $serviceOrder = ServiceOrder::factory()->create();
+
+    $treatmentRecord = TreatmentRecord::create([
+        'service_order_id' => $serviceOrder->id,
+        'department_id' => $serviceOrder->service->service_department_id,
+        'treating_doctor_id' => User::factory()->create()->id,
+        'recorded_by' => User::factory()->create()->id,
+        'treated_at' => now(),
+    ]);
+
+    expect(DeathCertificate::where('service_order_id', $serviceOrder->id)->count())->toBe(0);
+
+    $treatmentRecord->update(['outcome' => 'expired', 'outcome_at' => now()]);
+
+    expect(DeathCertificate::where('service_order_id', $serviceOrder->id)->count())->toBe(1);
+});
+
+test('a death certificate is not duplicated if the treatment record is saved again', function () {
+    $serviceOrder = ServiceOrder::factory()->create();
+
+    $treatmentRecord = TreatmentRecord::create([
+        'service_order_id' => $serviceOrder->id,
+        'department_id' => $serviceOrder->service->service_department_id,
+        'treating_doctor_id' => User::factory()->create()->id,
+        'recorded_by' => User::factory()->create()->id,
+        'treated_at' => now(),
+        'outcome' => 'expired',
+        'outcome_at' => now(),
+    ]);
+
+    $treatmentRecord->touch(); // re-fires the saved() event without changing outcome
+
+    expect(DeathCertificate::where('service_order_id', $serviceOrder->id)->count())->toBe(1);
+});
+
+test('a death certificate is not created for non-expired outcomes', function () {
+    $serviceOrder = ServiceOrder::factory()->create();
+
+    TreatmentRecord::create([
+        'service_order_id' => $serviceOrder->id,
+        'department_id' => $serviceOrder->service->service_department_id,
+        'treating_doctor_id' => User::factory()->create()->id,
+        'recorded_by' => User::factory()->create()->id,
+        'treated_at' => now(),
+        'outcome' => 'discharged',
+        'outcome_at' => now(),
+    ]);
+
+    expect(DeathCertificate::where('service_order_id', $serviceOrder->id)->exists())->toBeFalse();
+});
+
+test('the auto-created death certificate derives date/time of death, place, and informant from the record', function () {
+    $patient = Patient::factory()->create(['guardian' => 'Muhammad Ali', 'relation' => 'S/o']);
+    $department = ServiceDepartment::factory()->create(['name' => 'Emergency']);
+    $serviceOrder = ServiceOrder::factory()->create(['patient_id' => $patient->id]);
+    $outcomeAt = now()->subHour();
+
+    TreatmentRecord::create([
+        'service_order_id' => $serviceOrder->id,
+        'department_id' => $department->id,
+        'treating_doctor_id' => User::factory()->create()->id,
+        'recorded_by' => User::factory()->create()->id,
+        'treated_at' => now(),
+        'outcome' => 'expired',
+        'outcome_at' => $outcomeAt,
+    ]);
+
+    $certificate = DeathCertificate::where('service_order_id', $serviceOrder->id)->first();
+
+    expect($certificate->date_of_death->toDateString())->toBe($outcomeAt->toDateString())
+        ->and($certificate->place_of_death)->toBe('Emergency')
+        ->and($certificate->informant_name)->toBe('Muhammad Ali')
+        ->and($certificate->informant_relation)->toBe('S/o');
+});
+
+test('a referral certificate is auto-created when outcome is set to referred', function () {
+    $serviceOrder = ServiceOrder::factory()->create();
+
+    TreatmentRecord::create([
+        'service_order_id' => $serviceOrder->id,
+        'department_id' => $serviceOrder->service->service_department_id,
+        'treating_doctor_id' => User::factory()->create()->id,
+        'recorded_by' => User::factory()->create()->id,
+        'treated_at' => now(),
+        'outcome' => 'referred',
+        'outcome_at' => now(),
+        'referral_to' => 'City General Hospital',
+    ]);
+
+    $referral = ReferralCertificate::where('service_order_id', $serviceOrder->id)->first();
+
+    expect($referral)->not->toBeNull()
+        ->and($referral->receiving_facility_name)->toBe('City General Hospital');
+});
+
+test('a referral certificate is not duplicated on subsequent saves', function () {
+    $serviceOrder = ServiceOrder::factory()->create();
+
+    $treatmentRecord = TreatmentRecord::create([
+        'service_order_id' => $serviceOrder->id,
+        'department_id' => $serviceOrder->service->service_department_id,
+        'treating_doctor_id' => User::factory()->create()->id,
+        'recorded_by' => User::factory()->create()->id,
+        'treated_at' => now(),
+        'outcome' => 'referred',
+        'outcome_at' => now(),
+        'referral_to' => 'City General Hospital',
+    ]);
+
+    $treatmentRecord->touch();
+
+    expect(ReferralCertificate::where('service_order_id', $serviceOrder->id)->count())->toBe(1);
+});
+
+test('neither certificate is created for improved/unchanged/deteriorated/discharged outcomes', function () {
+    foreach (['improved', 'unchanged', 'deteriorated', 'discharged'] as $outcome) {
+        $serviceOrder = ServiceOrder::factory()->create();
+
+        TreatmentRecord::create([
+            'service_order_id' => $serviceOrder->id,
+            'department_id' => $serviceOrder->service->service_department_id,
+            'treating_doctor_id' => User::factory()->create()->id,
+            'recorded_by' => User::factory()->create()->id,
+            'treated_at' => now(),
+            'outcome' => $outcome,
+            'outcome_at' => now(),
+        ]);
+
+        expect(DeathCertificate::where('service_order_id', $serviceOrder->id)->exists())->toBeFalse()
+            ->and(ReferralCertificate::where('service_order_id', $serviceOrder->id)->exists())->toBeFalse();
+    }
+});

--- a/tests/Feature/Prints/ServiceOrderPdfPrintTest.php
+++ b/tests/Feature/Prints/ServiceOrderPdfPrintTest.php
@@ -2,8 +2,12 @@
 
 use App\Enum\ServiceOrderTemplate;
 use App\Helpers\DateHelper;
+use App\Helpers\QrCodeHelper;
+use App\Models\BirthCertificate;
+use App\Models\DeathCertificate;
 use App\Models\EmergencyDoctor;
 use App\Models\Patient;
+use App\Models\ReferralCertificate;
 use App\Models\Service;
 use App\Models\ServiceDepartment;
 use App\Models\ServiceOrder;
@@ -425,4 +429,133 @@ test('treatment given section only pads with one blank row once a treatment plan
 
     // 1 content row + 1 trailing blank row (marker sits inside the header row, so it's excluded).
     expect(rowCountBetween($html, 'TREATMENT GIVEN:', '</table>'))->toBe(2);
+});
+
+test('a death certificate is appended as extra pages when one exists for the service order', function () {
+    actingAs(User::factory()->create());
+
+    $serviceOrder = ServiceOrder::factory()->create(['type' => 'EMG']);
+    DeathCertificate::factory()->create(['service_order_id' => $serviceOrder->id]);
+
+    Pdf::shouldReceive('loadHTML')
+        ->once()
+        ->withArgs(fn (string $html) => str_contains($html, 'MEDICAL CERTIFICATE OF CAUSE OF DEATH'))
+        ->andReturnSelf();
+    Pdf::shouldReceive('setPaper')->once()->with('A4')->andReturnSelf();
+    Pdf::shouldReceive('stream')->once()->andReturn(response('%PDF-1.4 fake', 200, ['Content-Type' => 'application/pdf']));
+
+    get(route('print-serviceorder', ['id' => $serviceOrder->id]))->assertOk();
+});
+
+test('a referral certificate is appended as extra pages when one exists for the service order', function () {
+    actingAs(User::factory()->create());
+
+    $serviceOrder = ServiceOrder::factory()->create(['type' => 'EMG']);
+    ReferralCertificate::factory()->create([
+        'service_order_id' => $serviceOrder->id,
+        'notes' => '<p>Stable for transfer.</p>',
+    ]);
+
+    Pdf::shouldReceive('loadHTML')
+        ->once()
+        ->withArgs(fn (string $html) => str_contains($html, 'REFERRAL CERTIFICATE') && str_contains($html, 'Stable for transfer'))
+        ->andReturnSelf();
+    Pdf::shouldReceive('setPaper')->once()->with('A4')->andReturnSelf();
+    Pdf::shouldReceive('stream')->once()->andReturn(response('%PDF-1.4 fake', 200, ['Content-Type' => 'application/pdf']));
+
+    get(route('print-serviceorder', ['id' => $serviceOrder->id]))->assertOk();
+});
+
+test('no extra certificate pages are appended when none exist for the service order', function () {
+    actingAs(User::factory()->create());
+
+    $serviceOrder = ServiceOrder::factory()->create(['type' => 'EMG']);
+
+    Pdf::shouldReceive('loadHTML')
+        ->once()
+        ->withArgs(fn (string $html) => ! str_contains($html, 'MEDICAL CERTIFICATE OF CAUSE OF DEATH')
+            && ! str_contains($html, 'REFERRAL CERTIFICATE')
+            && ! str_contains($html, 'BIRTH CERTIFICATE'))
+        ->andReturnSelf();
+    Pdf::shouldReceive('setPaper')->once()->with('A4')->andReturnSelf();
+    Pdf::shouldReceive('stream')->once()->andReturn(response('%PDF-1.4 fake', 200, ['Content-Type' => 'application/pdf']));
+
+    get(route('print-serviceorder', ['id' => $serviceOrder->id]))->assertOk();
+});
+
+test('a locked birth certificate is appended as extra pages when printing the service order', function () {
+    actingAs(User::factory()->create());
+
+    $serviceOrder = ServiceOrder::factory()->create(['type' => 'IND']);
+    BirthCertificate::factory()->locked()->create([
+        'service_order_id' => $serviceOrder->id,
+        'child_name' => 'Baby Ahmed',
+    ]);
+
+    Pdf::shouldReceive('loadHTML')
+        ->once()
+        ->withArgs(fn (string $html) => str_contains($html, 'BIRTH CERTIFICATE') && str_contains($html, 'Baby Ahmed'))
+        ->andReturnSelf();
+    Pdf::shouldReceive('setPaper')->once()->with('A4')->andReturnSelf();
+    Pdf::shouldReceive('stream')->once()->andReturn(response('%PDF-1.4 fake', 200, ['Content-Type' => 'application/pdf']));
+
+    get(route('print-serviceorder', ['id' => $serviceOrder->id]))->assertOk();
+});
+
+test('an unlocked birth certificate is never appended when printing the service order', function () {
+    actingAs(User::factory()->create());
+
+    $serviceOrder = ServiceOrder::factory()->create(['type' => 'IND']);
+    BirthCertificate::factory()->create([
+        'service_order_id' => $serviceOrder->id,
+        'child_name' => 'Baby Ahmed',
+        'is_locked' => false,
+    ]);
+
+    Pdf::shouldReceive('loadHTML')
+        ->once()
+        ->withArgs(fn (string $html) => ! str_contains($html, 'BIRTH CERTIFICATE'))
+        ->andReturnSelf();
+    Pdf::shouldReceive('setPaper')->once()->with('A4')->andReturnSelf();
+    Pdf::shouldReceive('stream')->once()->andReturn(response('%PDF-1.4 fake', 200, ['Content-Type' => 'application/pdf']));
+
+    get(route('print-serviceorder', ['id' => $serviceOrder->id]))->assertOk();
+});
+
+test('the appended death certificate page embeds a scannable QR verification code', function () {
+    actingAs(User::factory()->create());
+
+    $serviceOrder = ServiceOrder::factory()->create(['type' => 'EMG']);
+    $certificate = DeathCertificate::factory()->create(['service_order_id' => $serviceOrder->id]);
+
+    $expectedUrl = QrCodeHelper::verificationUrl('v/dc/'.$certificate->verification_token);
+    $expectedDataUri = QrCodeHelper::dataUri($expectedUrl, 48);
+
+    Pdf::shouldReceive('loadHTML')
+        ->once()
+        ->withArgs(fn (string $html) => str_contains($html, $expectedDataUri))
+        ->andReturnSelf();
+    Pdf::shouldReceive('setPaper')->once()->with('A4')->andReturnSelf();
+    Pdf::shouldReceive('stream')->once()->andReturn(response('%PDF-1.4 fake', 200, ['Content-Type' => 'application/pdf']));
+
+    get(route('print-serviceorder', ['id' => $serviceOrder->id]))->assertOk();
+});
+
+test('the appended birth certificate page embeds a scannable QR verification code', function () {
+    actingAs(User::factory()->create());
+
+    $serviceOrder = ServiceOrder::factory()->create(['type' => 'IND']);
+    $certificate = BirthCertificate::factory()->locked()->create(['service_order_id' => $serviceOrder->id]);
+
+    $expectedUrl = QrCodeHelper::verificationUrl('v/bc/'.$certificate->verification_token);
+    $expectedDataUri = QrCodeHelper::dataUri($expectedUrl, 48);
+
+    Pdf::shouldReceive('loadHTML')
+        ->once()
+        ->withArgs(fn (string $html) => str_contains($html, $expectedDataUri))
+        ->andReturnSelf();
+    Pdf::shouldReceive('setPaper')->once()->with('A4')->andReturnSelf();
+    Pdf::shouldReceive('stream')->once()->andReturn(response('%PDF-1.4 fake', 200, ['Content-Type' => 'application/pdf']));
+
+    get(route('print-serviceorder', ['id' => $serviceOrder->id]))->assertOk();
 });

--- a/tests/Feature/Public/CertificateVerificationTest.php
+++ b/tests/Feature/Public/CertificateVerificationTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use App\Models\BirthCertificate;
+use App\Models\DeathCertificate;
+use App\Models\Patient;
+use App\Models\ServiceOrder;
+
+use function Pest\Laravel\get;
+
+test('a valid death certificate verification token shows the public page', function () {
+    $patient = Patient::factory()->create(['name' => 'Verify Test Patient']);
+    $serviceOrder = ServiceOrder::factory()->create(['patient_id' => $patient->id]);
+    $certificate = DeathCertificate::factory()->create(['service_order_id' => $serviceOrder->id]);
+
+    get(route('public-death-certificate', ['token' => $certificate->verification_token]))
+        ->assertOk()
+        ->assertSee('Verify Test Patient')
+        ->assertSee($certificate->certificate_number);
+});
+
+test('an unknown death certificate verification token 404s', function () {
+    get(route('public-death-certificate', ['token' => 'not-a-real-token']))
+        ->assertNotFound();
+});
+
+test('the death certificate verification page does not require authentication', function () {
+    $certificate = DeathCertificate::factory()->create();
+
+    // No actingAs() call — guest request.
+    get(route('public-death-certificate', ['token' => $certificate->verification_token]))
+        ->assertOk();
+});
+
+test('a locked birth certificate verification token shows the public page', function () {
+    $patient = Patient::factory()->create(['name' => 'Baby Verify Test']);
+    $serviceOrder = ServiceOrder::factory()->create(['patient_id' => $patient->id]);
+    $certificate = BirthCertificate::factory()->locked()->create([
+        'service_order_id' => $serviceOrder->id,
+        'child_name' => 'Baby Verify',
+    ]);
+
+    get(route('public-birth-certificate', ['token' => $certificate->verification_token]))
+        ->assertOk()
+        ->assertSee('Baby Verify')
+        ->assertSee($certificate->birth_certificate_number);
+});
+
+test('an unlocked birth certificate verification token 404s even with a valid token', function () {
+    $certificate = BirthCertificate::factory()->create(['is_locked' => false]);
+
+    get(route('public-birth-certificate', ['token' => $certificate->verification_token]))
+        ->assertNotFound();
+});
+
+test('an unknown birth certificate verification token 404s', function () {
+    get(route('public-birth-certificate', ['token' => 'not-a-real-token']))
+        ->assertNotFound();
+});


### PR DESCRIPTION
## Summary
- **Death Certificate** — auto-created (`TreatmentRecordObserver`) when a treatment record's `outcome` becomes `Expired`. WHO-style fields (manner of death, antecedent cause, informant). Admin-editable via a new Filament resource.
- **Referral Certificate** — auto-created skeleton on `outcome = Referred`; doctor authors the actual letter via a CKEditor5 rich-text field shown in the finalize form, with 4 mention feeds: `#` drug, `@` doctor, `&` ICD-10 code, `!` closing/transaction number. Notes are sanitized server-side before storage.
- **Birth Certificate** — admin-created only (not outcome-triggered), looked up by SO number **or** SO short code. One-way **Lock** action — locked certificates can never be edited again (enforced at the model level, not just the UI), and only print once locked.
- All three certificate types append as extra pages onto the existing `PRINT/SO/{id}` PDF when present, using the same base templates.
- **QR verification** — Death and Birth certificates carry a 48×48 QR code linking to a short, unauthenticated public page (`/v/dc/{token}`, `/v/bc/{token}`), gated by a random 40-char token rather than a login wall. The Birth certificate's public page 404s until locked, matching print gating. Base domain configurable via a new **Hospital Settings → Certificate Verification Domain** field.

Closes #36.

## New dependencies
- `@ckeditor/ckeditor5-react` + `ckeditor5` (npm) — open-source/GPL, lazy-loaded so the base `DeptPatientForm` bundle stays at ~35KB instead of +700KB.
- `endroid/qr-code` (composer) — clean per `composer audit`.

## Known scope boundaries
- The CKEditor referral-notes editor only appears in the shared `DeptPatientForm.tsx` (EMG/DNT/LAB/ULT/XRAY). OPD and IND have their own separate finalize forms without it — referrals from those departments still auto-create a `ReferralCertificate`, but notes need to be added afterward via the Filament admin resource.
- EMG's `DischargeDialog` "Referred to Other Hospital" path sets the outcome (certificate still auto-creates) but doesn't show the CKEditor either.

## Test plan
- [x] `php artisan test --compact` — full suite: 709 passed, 1 pre-existing unrelated failure (`AbacusClosingIntegrationTest`, confirmed failing on `main` too), 1 skipped
- [x] New coverage: observer auto-creation (create + update transitions, no duplication, no false triggers on other outcomes), model immutability guards (birth cert lock, no hard deletes), number generation/uniqueness for all 3 types, print-controller page-append logic (incl. QR embedding), public verification routes (valid/invalid/unlocked-gated), Filament CRUD + Lock action, `referral_notes` passthrough + sanitization
- [x] `vendor/bin/pint --dirty` clean
- [x] `tsc --noEmit` — no new errors (pre-existing unrelated Wayfinder `.form()` errors only)
- [x] `pnpm run build` succeeds; confirmed CKEditor lazy-chunk split (`DeptPatientForm` 717KB → 35KB)
- [x] Manual end-to-end verification via tinker: death/referral/birth certificate creation, lock enforcement, QR data URI generation, public page 200/404 behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)