### PR TITLE
fix: resolve service department image path after Filament edit

### DIFF
--- a/app/Filament/Admin/Resources/ServiceDepartments/ServiceDepartmentResource.php
+++ b/app/Filament/Admin/Resources/ServiceDepartments/ServiceDepartmentResource.php
@@ -18,7 +18,6 @@ use Filament\Schemas\Schema;
 use Filament\Tables\Columns\ImageColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
-use Illuminate\Support\Str;
 use UnitEnum;
 
 class ServiceDepartmentResource extends Resource
@@ -42,6 +41,8 @@ class ServiceDepartmentResource extends Resource
                 FileUpload::make('image')
                     ->image()
                     ->disk('public')
+                    ->directory('service-departments')
+                    ->visibility('public')
                     ->required(),
                 TextInput::make('have_composit_services')
                     ->required()
@@ -65,18 +66,8 @@ class ServiceDepartmentResource extends Resource
                     ->searchable(),
                 TextColumn::make('slug')
                     ->searchable(),
-                ImageColumn::make('image')
-                    ->disk('public')
-                    ->state(function ($record) {
-                        // Edit the state before rendering
-                        if (Str::startsWith($record->image, 'http://') || Str::startsWith($record->image, 'https://')) {
-                            return $record->image;
-                        } elseif (Str::startsWith($record->image, '/img/')) {
-                            return asset($record->image);
-                        }
-
-                        return asset('storage/'.$record->image);
-                    }),
+                ImageColumn::make('image_url')
+                    ->label('Image'),
                 TextColumn::make('have_composit_services')
                     ->numeric()
                     ->sortable(),

--- a/app/Models/ServiceDepartment.php
+++ b/app/Models/ServiceDepartment.php
@@ -5,6 +5,8 @@ namespace App\Models;
 use App\Enum\ServiceOrderTemplate;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 
 class ServiceDepartment extends Model
 {
@@ -20,6 +22,10 @@ class ServiceDepartment extends Model
         'service_order_template',
     ];
 
+    protected $appends = [
+        'image_url',
+    ];
+
     protected $casts = [
         'have_composit_services' => 'boolean',
         'service_order_template' => ServiceOrderTemplate::class,
@@ -28,5 +34,28 @@ class ServiceDepartment extends Model
     public function services()
     {
         return $this->hasMany(Service::class, 'service_department_id');
+    }
+
+    /**
+     * Resolve `image` into a renderable URL regardless of which format it's
+     * stored in — a seeded public-folder path (`/img/emergency.png`), a full
+     * URL, or a Filament FileUpload storage-disk path — so both the admin
+     * table and the frontend share one resolution instead of duplicating it.
+     */
+    public function getImageUrlAttribute(): ?string
+    {
+        if (empty($this->image)) {
+            return null;
+        }
+
+        if (Str::startsWith($this->image, ['http://', 'https://'])) {
+            return $this->image;
+        }
+
+        if (Str::startsWith($this->image, '/img/')) {
+            return asset($this->image);
+        }
+
+        return Storage::disk('public')->url($this->image);
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - APP_NAME=HospitalCare
       - APP_ENV=local
       - APP_DEBUG=true
-      - APP_URL=http://localhost:8000
+      - APP_URL=http://localhost
       - REGISTER_PATIENT_PUBLICLY=true
       - TAKE_APPOINTMENTS_PUBLICLY=true
       - SESSION_DOMAIN=localhost
@@ -33,7 +33,7 @@ services:
       - APP_NAME=HospitalCare
       - APP_ENV=local
       - APP_DEBUG=true
-      - APP_URL=http://localhost:8000
+      - APP_URL=http://localhost
       - REGISTER_PATIENT_PUBLICLY=true
       - TAKE_APPOINTMENTS_PUBLICLY=true
       - SESSION_DOMAIN=localhost

--- a/docs/fixes/README.md
+++ b/docs/fixes/README.md
@@ -19,3 +19,4 @@ Each fix is documented from four perspectives so every stakeholder has the infor
 | 2 | [#4](https://github.com/afaryab/hospital-care/issues/4) | Missing authorization — resource-level access control | Critical | ✅ Fixed |
 | 3 | [#5](https://github.com/afaryab/hospital-care/issues/5) | CNIC patient search uses wrong variable | High | ✅ Fixed |
 | 4 | [#34](https://github.com/afaryab/hospital-care/issues/34) | Configurable 1-page compact emergency triage print template | Enhancement | ✅ Implemented (PR #35) |
+| 5 | [#38](https://github.com/afaryab/hospital-care/issues/38) | Service department image breaks after editing via Filament | Medium | ✅ Fixed |

--- a/docs/fixes/fix-005-service-department-image-broken-after-edit.md
+++ b/docs/fixes/fix-005-service-department-image-broken-after-edit.md
@@ -1,0 +1,112 @@
+# Fix #005 — Service Department Image Breaks After Editing via Filament
+
+**GitHub Issue:** [afaryab/hospital-care#38](https://github.com/afaryab/hospital-care/issues/38)
+**Severity:** Medium
+**Status:** ✅ Fixed
+**Branch:** `fix/service-department-image-upload-path`
+**Date:** 2026-08-11
+
+---
+
+## For Developers
+
+### What was wrong
+
+Two compounding bugs, both confirmed by tracing Filament's `FileUpload` source and live-testing in Docker:
+
+**1. No centralized image URL resolution.** Filament's `FileUpload::make('image')` (no `->directory()` set) stores newly-uploaded files as a bare ULID filename with **no path prefix at all** — e.g. `01KA9TMXFD8H1BW3XBRTRG3ZNJ.png` — traced through `vendor/filament/forms/src/Components/BaseFileUpload.php`'s default `saveUploadedFileUsing`. Seeded rows use a completely different, incompatible format: `/img/emergency.png` (a `public/` folder path).
+
+`ServiceDepartmentResource`'s Filament table had ad-hoc logic to handle both formats, but it existed **only** there. Every frontend render site used the raw `image` field directly with zero resolution:
+- `resources/js/elements/department/mini-card.tsx`
+- `resources/js/pages/patient.tsx`
+- `resources/js/pages/counter/income.tsx` (×2)
+
+Seeded `/img/*.png` values happened to render correctly by accident (root-relative path). Post-edit bare-filename values were a guaranteed 404 — the browser resolves a path with no leading slash relative to the *current page URL*, not the site root.
+
+**2. `APP_URL` didn't match the actual served port**, breaking even the Filament table's own fallback. `docker-compose.yml` set `APP_URL=http://localhost:8000` for the `app`/`cli` services, but `app`'s port mapping is `"80:80"`. Verified live: `curl http://localhost:8000/storage/...` failed to connect; `curl http://localhost:80/storage/...` returned 200. `.env.example` already had the correct value — `docker-compose.yml`'s override was the actual bug.
+
+### Fix
+
+- Added `ServiceDepartment::getImageUrlAttribute()` (appended as `image_url`), centralizing the http(s)/`/img/`/storage-disk resolution in one place instead of duplicating it.
+- Filament's `ImageColumn` now points at `image_url` directly — the inline `Str::startsWith` closure is gone.
+- All 4 frontend render sites switched from `image`/`dept.image` to `image_url`; `ServiceDepartment` TS type updated.
+- `FileUpload::make('image')` now sets `->directory('service-departments')` and `->visibility('public')` for clarity/organization (not the root cause, but matches project convention).
+- Fixed `docker-compose.yml`'s `APP_URL` to match the actual exposed port.
+
+No data migration needed — this is a read-time resolution fix, not a stored-data format change. Existing bare-filename rows from before the fix resolve correctly the moment `image_url` is read.
+
+### Files changed
+
+- `app/Models/ServiceDepartment.php` — `image_url` accessor + `$appends`
+- `app/Filament/Admin/Resources/ServiceDepartments/ServiceDepartmentResource.php` — simplified `ImageColumn`, `FileUpload` directory/visibility
+- `resources/js/elements/department/mini-card.tsx`, `resources/js/pages/patient.tsx`, `resources/js/pages/counter/income.tsx` — use `image_url`
+- `resources/js/types/index.d.ts` — `ServiceDepartment.image_url`
+- `docker-compose.yml` — `APP_URL` fix
+- `tests/Feature/Models/ServiceDepartmentModelTest.php`, `tests/Feature/Filament/Admin/ServiceDepartmentResourceTest.php` — new coverage
+
+### Tests
+
+```bash
+php artisan test --compact tests/Feature/Models/ServiceDepartmentModelTest.php tests/Feature/Filament/Admin/ServiceDepartmentResourceTest.php
+```
+
+16 tests / 37 assertions, all passing. New coverage: `image_url` for all three input formats (URL passthrough, `/img/` passthrough, storage-disk path) plus the empty-image case; a Filament end-to-end test uploading a fake image and asserting the resolved `image_url` starts with `/storage/service-departments/` rather than the raw bare filename; a table-column state assertion. Full suite: 716 passed, 1 pre-existing unrelated failure, 1 skipped.
+
+### Manual verification
+
+Live-tested in the actual Docker environment after recreating containers with the fixed `APP_URL`: created departments with both a seeded-style path and an uploaded-style path, confirmed `image_url` resolved to `http://localhost/img/emergency.png` and `http://localhost/storage/service-departments/....png` respectively, and `curl`'d both — both returned `200`.
+
+---
+
+## For IT / DevOps
+
+### What changed on the server
+
+No schema changes, no migrations. One `.env`-equivalent value changed in `docker-compose.yml` (`APP_URL`).
+
+### Deployment steps
+
+1. Pull latest code.
+2. If your deployment's real `APP_URL` differs from `http://localhost` (e.g. a real domain in staging/production), no action needed — `docker-compose.yml`'s value only affects local dev; production environments should already have their own correct `APP_URL` in their actual `.env`/secrets, unaffected by this change.
+3. `docker compose up -d --build` (or standard deploy) to pick up the code changes. No artisan commands required.
+
+### How to verify after deploy
+
+1. In `/admin` → Services → Service Departments, edit a department's image and save.
+2. Confirm the image now displays correctly in the admin table.
+3. Visit the frontend Counter income page and confirm the department icon renders there too.
+
+### Rollback
+
+Revert the listed files via git. No data was changed, so rollback is a pure code revert.
+
+### Risk
+
+**Low.** The accessor is purely additive (new computed field); existing `image` column and its consumers elsewhere are untouched. `APP_URL` in `docker-compose.yml` only affects local Docker Compose dev environments — production deployments manage their own environment configuration separately.
+
+---
+
+## For Reception Staff
+
+### What changed?
+
+Department icons (in the Counter income screen and elsewhere) will now display correctly after an administrator updates a department's picture in the admin panel. Previously, editing a department's image would cause its icon to disappear until someone manually fixed the underlying file path.
+
+---
+
+## For Hospital Administration
+
+### Business impact
+
+| Scenario | Before fix | After fix |
+|---|---|---|
+| Admin updates a department's icon via Filament | Icon disappears everywhere (admin + reception-facing Counter screen) | Icon updates and displays correctly everywhere |
+| Diagnosing the broken icon | Required a developer to inspect the database and file storage | No longer occurs |
+
+### Compliance relevance
+
+None — this is a cosmetic/display bug affecting department branding icons, not patient data, financial records, or clinical information.
+
+### Data impact
+
+No patient, financial, or clinical data was affected. Existing department image references remain valid; only how they're *displayed* changed.

--- a/resources/js/elements/department/mini-card.tsx
+++ b/resources/js/elements/department/mini-card.tsx
@@ -36,7 +36,7 @@ export default function DepartmentMiniCard({
                 className="flex h-full w-32 flex-col items-center justify-center"
             >
                 <img
-                    src={department.image}
+                    src={department.image_url}
                     alt={department.name}
                     className="h-12 w-12 object-contain"
                 />

--- a/resources/js/pages/counter/income.tsx
+++ b/resources/js/pages/counter/income.tsx
@@ -1201,7 +1201,7 @@ function SelectDepartment({ openCounter, patient, departments }: any) {
                                 className="flex h-32 w-32 flex-col items-center justify-center rounded-xl border"
                             >
                                 <img
-                                    src={department.image}
+                                    src={department.image_url}
                                     alt={department.name}
                                     className="h-12 w-12 object-contain"
                                 />
@@ -1236,7 +1236,7 @@ function SelectDepartment({ openCounter, patient, departments }: any) {
                                     className="flex h-32 w-32 flex-col items-center justify-center rounded-xl border"
                                 >
                                     <img
-                                        src={department.image}
+                                        src={department.image_url}
                                         alt={department.name}
                                         className="h-12 w-12 object-contain"
                                     />

--- a/resources/js/pages/patient.tsx
+++ b/resources/js/pages/patient.tsx
@@ -81,7 +81,7 @@ export default function PatientView() {
                                     className="flex cursor-pointer flex-row gap-2 p-4"
                                 >
                                     <img
-                                        src={dept.image}
+                                        src={dept.image_url}
                                         alt={dept.name}
                                         className="h-12 w-12"
                                     />

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -76,6 +76,8 @@ export interface ServiceDepartment {
     name: string;
     slug: string;
     image?: string;
+    /** Resolved, renderable URL — always use this over `image` for <img src>. */
+    image_url?: string;
 }
 
 export interface Service {

--- a/tests/Feature/Filament/Admin/ServiceDepartmentResourceTest.php
+++ b/tests/Feature/Filament/Admin/ServiceDepartmentResourceTest.php
@@ -59,3 +59,33 @@ test('service department print template is left unset when not chosen', function
         'service_order_template' => null,
     ]);
 });
+
+test('the uploaded image resolves to a working public storage URL, not a bare filename', function () {
+    Livewire\Livewire::test(ManageServiceDepartments::class)
+        ->callAction('create', data: [
+            'name' => 'Radiology',
+            'slug' => 'RAD-2',
+            'image' => UploadedFile::fake()->image('xray.jpg'),
+            'have_composit_services' => 0,
+        ])
+        ->assertNotified();
+
+    $department = ServiceDepartment::where('name', 'Radiology')->firstOrFail();
+
+    // Filament's FileUpload saves a bare disk-relative path (e.g.
+    // "service-departments/01AB....jpg", no leading slash) — that's exactly
+    // what broke <img src> before this fix, since the browser resolves it
+    // relative to the current page URL instead of the site root. The
+    // accessor must turn it into a root-relative or absolute URL that
+    // actually points at the file.
+    expect($department->image)->not->toStartWith('http')
+        ->and($department->image)->not->toStartWith('/img/')
+        ->and($department->image_url)->toStartWith('/storage/service-departments/');
+});
+
+test('the service department table renders the resolved image_url, not a broken raw path', function () {
+    $department = ServiceDepartment::factory()->create(['image' => '/img/emergency.png']);
+
+    Livewire\Livewire::test(ManageServiceDepartments::class)
+        ->assertTableColumnStateSet('image_url', $department->image_url, record: $department);
+});

--- a/tests/Feature/Models/ServiceDepartmentModelTest.php
+++ b/tests/Feature/Models/ServiceDepartmentModelTest.php
@@ -3,6 +3,7 @@
 use App\Enum\ServiceOrderTemplate;
 use App\Models\ServiceDepartment;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Facades\Storage;
 
 test('service department can be created with factory', function () {
     $department = ServiceDepartment::factory()->create();
@@ -34,4 +35,37 @@ test('service department casts service_order_template to the enum', function () 
     ]);
 
     expect($department->fresh()->service_order_template)->toBe(ServiceOrderTemplate::EmergencyTriageCompact);
+});
+
+test('image_url passes through a seeded /img/ public-folder path as an absolute URL', function () {
+    $department = ServiceDepartment::factory()->create(['image' => '/img/emergency.png']);
+
+    expect($department->image_url)->toBe(asset('/img/emergency.png'));
+});
+
+test('image_url passes through a full http(s) URL unchanged', function () {
+    $department = ServiceDepartment::factory()->create(['image' => 'https://cdn.example.com/logo.png']);
+
+    expect($department->image_url)->toBe('https://cdn.example.com/logo.png');
+});
+
+test('image_url resolves a Filament FileUpload storage-disk path (no leading slash) to a public storage URL', function () {
+    // This is exactly what Filament's FileUpload saves after an edit — a bare
+    // disk-relative path with no leading slash and no "storage/" prefix.
+    $department = ServiceDepartment::factory()->create(['image' => 'service-departments/01ABCDEF.png']);
+
+    expect($department->image_url)->toBe(Storage::disk('public')->url('service-departments/01ABCDEF.png'))
+        ->and($department->image_url)->toContain('/storage/service-departments/01ABCDEF.png');
+});
+
+test('image_url is null when no image is set', function () {
+    $department = ServiceDepartment::factory()->create(['image' => '']);
+
+    expect($department->image_url)->toBeNull();
+});
+
+test('image_url is appended when the model is serialized', function () {
+    $department = ServiceDepartment::factory()->create(['image' => '/img/emergency.png']);
+
+    expect($department->toArray())->toHaveKey('image_url');
 });


### PR DESCRIPTION
## Summary
After an admin edits a Service Department's image via Filament, the icon disappears everywhere (admin table + frontend Counter page). Two compounding bugs, confirmed by tracing Filament's `FileUpload` source and live-testing in Docker:

1. **No centralized image resolution.** Filament's `FileUpload` (no `->directory()`) saves uploaded images as a bare filename with zero path prefix (e.g. `01KA9T...png`). Seeded departments use `/img/emergency.png` — a totally different format. The Filament admin table had ad-hoc logic to handle both formats, but it existed *only* there — every frontend render site (`mini-card.tsx`, `patient.tsx`, `counter/income.tsx` ×2) used the raw `image` field directly. Seeded values rendered by accident (root-relative path); post-edit values were a guaranteed 404.
2. **`APP_URL` didn't match the actual served port** — `docker-compose.yml` had `:8000` while the app is mapped to port `80`. Verified live: port 8000 failed to connect, port 80 returned 200. This broke even the admin table's own fallback logic.

## Fix
- Added `ServiceDepartment::image_url` (accessor, appended) — single source of truth for resolving `http(s)://`, `/img/...`, and storage-disk paths into a renderable URL.
- Filament's `ImageColumn` now points at `image_url` directly; the inline `Str::startsWith` closure is gone.
- All 4 frontend render sites + the `ServiceDepartment` TS type updated to use `image_url`.
- `FileUpload::make('image')` now sets `->directory('service-departments')` and `->visibility('public')` for clarity.
- Fixed `docker-compose.yml`'s `APP_URL` to match the actual exposed port.

No data migration needed — read-time resolution fix, not a stored-data format change.

Closes #38.

## Test plan
- [x] `php artisan test --compact` — full suite: 716 passed (7 new), 1 pre-existing unrelated failure, 1 skipped
- [x] New coverage: `image_url` for all 3 input formats + empty case, Filament end-to-end upload test asserting the resolved URL (not the raw bare filename), table-column state assertion
- [x] `vendor/bin/pint --dirty` clean, `vendor/bin/filacheck` — all 16 rules pass
- [x] `tsc --noEmit`, ESLint, Prettier — no new issues
- [x] `vite build` succeeds
- [x] Manual end-to-end verification: recreated containers with the fixed `APP_URL`, created departments with both a seeded-style and uploaded-style path, `curl`'d both resolved URLs — both return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)